### PR TITLE
en messages patch 1

### DIFF
--- a/Tab-Session-Manager/_locales/en/messages.json
+++ b/Tab-Session-Manager/_locales/en/messages.json
@@ -73,7 +73,7 @@
         "message": "Save the session every set time."
     },
     "autoSaveIntervalLabel": {
-        "message": "interval(minutes)"
+        "message": "Interval (minutes)"
     },
     "autoSaveIntervalCaptionLabel": {
         "message": "Minimum value 0.1"
@@ -112,7 +112,7 @@
         "message": "Import sessions"
     },
     "importCaptionLabel": {
-        "message": "Load sessions saved on the computer and add them to the current session.<br>It also supports SessionManager's session file (.session)."
+        "message": "Load sessions saved on the computer.<br>It also supports SessionManager's session file (.session)."
     },
     "importButtonLabel": {
         "message": "Reference..."

--- a/Tab-Session-Manager/_locales/en/messages.json
+++ b/Tab-Session-Manager/_locales/en/messages.json
@@ -112,7 +112,7 @@
         "message": "Import sessions"
     },
     "importCaptionLabel": {
-        "message": "Load sessions saved on the computer and add them to the current session.<br>It also supports SessionManager's session file (.session)."
+        "message": "Load sessions saved on the computer.<br>It also supports SessionManager's session file (.session)."
     },
     "importButtonLabel": {
         "message": "Reference..."

--- a/Tab-Session-Manager/_locales/en/messages.json
+++ b/Tab-Session-Manager/_locales/en/messages.json
@@ -106,13 +106,13 @@
         "message": "Supports Tree Style Tab"
     },
     "ifSupportTstCaptionLabel": {
-        "message": "Load sessions saved on the computer and add them to the current session.<br>Please turn it off if it is less than fireFox 57."
+        "message": "Restore tree state of Tree Style Tab.<br>Please turn it off if it is less than fireFox 57."
     },
     "importLabel": {
         "message": "Import sessions"
     },
     "importCaptionLabel": {
-        "message": "Load sessions saved on the computer.<br>It also supports SessionManager's session file (.session)."
+        "message": "Load sessions saved on the computer and add them to the current session.<br>It also supports SessionManager's session file (.session)."
     },
     "importButtonLabel": {
         "message": "Reference..."

--- a/Tab-Session-Manager/_locales/en/messages.json
+++ b/Tab-Session-Manager/_locales/en/messages.json
@@ -106,7 +106,7 @@
         "message": "Supports Tree Style Tab"
     },
     "ifSupportTstCaptionLabel": {
-        "message": "Restore tree state of Tree Style Tab.<br>Please turn it off if it is less than fireFox 57."
+        "message": "Load sessions saved on the computer and add them to the current session.<br>Please turn it off if it is less than fireFox 57."
     },
     "importLabel": {
         "message": "Import sessions"

--- a/Tab-Session-Manager/_locales/en/messages.json
+++ b/Tab-Session-Manager/_locales/en/messages.json
@@ -73,7 +73,7 @@
         "message": "Save the session every set time."
     },
     "autoSaveIntervalLabel": {
-        "message": "Interval (minutes)"
+        "message": "interval(minutes)"
     },
     "autoSaveIntervalCaptionLabel": {
         "message": "Minimum value 0.1"


### PR DESCRIPTION
"and add them to the current session." - That is not what actually happen. Imported sessions not added to current session. They just added to the saved-sessions list (what is obvious). So this phrase should be skipped.