### PR TITLE
Add simple update feature to overwrite sessions

### DIFF
--- a/Tab-Session-Manager/_locales/en/messages.json
+++ b/Tab-Session-Manager/_locales/en/messages.json
@@ -43,6 +43,9 @@
     "open": {
         "message": "Open"
     },
+    "update": {
+        "message": "Update"
+    },
     "remove": {
         "message": "Delete"
     },

--- a/Tab-Session-Manager/background/background.js
+++ b/Tab-Session-Manager/background/background.js
@@ -144,6 +144,10 @@ function onMessageListener(request, sender, sendResponse) {
             const property = request.property;
             saveCurrentSession(name, [], property).catch(() => {});
             break;
+        case "update":
+            removeSession(request.id);
+            saveCurrentSession(request.name, [], request.property).catch(() => {});
+            break;
         case "open":
             openSession(request.session, request.property);
             break;

--- a/Tab-Session-Manager/popup/popup.css
+++ b/Tab-Session-Manager/popup/popup.css
@@ -569,6 +569,7 @@ option {
 }
 
 .open,
+.update,
 .remove {
     color: var(--highlight);
     text-decoration: none;

--- a/Tab-Session-Manager/popup/popup.js
+++ b/Tab-Session-Manager/popup/popup.js
@@ -34,7 +34,7 @@ S.init().then(async() => {
 });
 
 async function setLabels() {
-    labels = ['initialNameValue', 'winCloseSessionName', 'regularSaveSessionName', 'displayAllLabel', 'displayUserLabel', 'displayAutoLabel', 'settingsLabel', 'open', 'remove', 'windowLabel', 'windowsLabel', 'tabLabel', 'tabsLabel', 'noSessionLabel', 'removeConfirmLabel', 'cancelLabel', 'renameLabel', 'exportButtonLabel', 'openInNewWindowLabel', 'openInCurrentWindowLabel', 'addToCurrentWindowLabel', 'saveOnlyCurrentWindowLabel', 'addTagLabel', 'removeTagLabel', 'donateWithPaypalLabel'];
+    labels = ['initialNameValue', 'winCloseSessionName', 'regularSaveSessionName', 'displayAllLabel', 'displayUserLabel', 'displayAutoLabel', 'settingsLabel', 'open', 'remove', 'update', 'windowLabel', 'windowsLabel', 'tabLabel', 'tabsLabel', 'noSessionLabel', 'removeConfirmLabel', 'cancelLabel', 'renameLabel', 'exportButtonLabel', 'openInNewWindowLabel', 'openInCurrentWindowLabel', 'addToCurrentWindowLabel', 'saveOnlyCurrentWindowLabel', 'addTagLabel', 'removeTagLabel', 'donateWithPaypalLabel'];
 
     for (let i of labels) {
         Labels[i] = browser.i18n.getMessage(i);
@@ -403,6 +403,7 @@ function sessionsHTML(info) {
             <div class=removeOpenButton>
                 <span class="open">${Labels.open}</span>
                 <span class="remove">${Labels.remove}</span>
+                <span class="update">${Labels.update}</span>
             </div>
         </div>
         <div class="removeConfirm hidden">
@@ -742,6 +743,9 @@ document.addEventListener('click', async function (e) {
         case "open":
             sendOpenMessage(e, "default");
             break;
+        case "update":
+            update(e);
+            break;
         case "remove":
         case "cancel":
             showRemoveConfirm(e);
@@ -832,4 +836,25 @@ function save(property = "default") {
         property: property
     });
     document.getElementById("saveName").value = "";
+}
+
+function getParentName(element) {
+    while (true) {
+        element = element.parentElement;
+        if (element.id != "") {
+            return element.getAttribute("data-name");
+        }
+    }
+}
+
+function update(e, property = "default") {
+    const id = getParentSessionId(e.target);
+    const name = getParentName(e.target);
+
+    browser.runtime.sendMessage({
+        message: "update",
+        id: id,
+        name: name,
+        property: property
+    });
 }


### PR DESCRIPTION
I love everything about this add-on but overwriting sessions is the only thing I really miss and I saw some people had created an Issue requesting the feature. So I just added an update button next to open and delete that overwrites the session with the current one.

Do with it whatever you want. :3 