### PR TITLE
Enables up/down key navigation in session list

### DIFF
--- a/src/popup/components/DonationMessage.js
+++ b/src/popup/components/DonationMessage.js
@@ -1,7 +1,7 @@
 import React from "react";
 import browser from "webextension-polyfill";
 import browserInfo from "browser-info";
-import "../styles/donationMessage.scss";
+import "../styles/DonationMessage.scss";
 
 export default props => {
   const isChrome = browserInfo().name == "Chrome";

--- a/src/popup/components/Modal.js
+++ b/src/popup/components/Modal.js
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import ReactDOM from "react-dom";
 import browser from "webextension-polyfill";
 import PlusIcon from "../icons/plus.svg";
-import "../styles/modal.scss";
+import "../styles/Modal.scss";
 
 export default class Modal extends Component {
   constructor(props) {

--- a/src/popup/components/SessionDetailsArea.js
+++ b/src/popup/components/SessionDetailsArea.js
@@ -12,7 +12,7 @@ import SessionMenuItems from "./SessionMenuItems";
 import MenuIcon from "../icons/menu.svg";
 import NewWindowIcon from "../icons/newWindow.svg";
 import DeleteIcon from "../icons/delete.svg";
-import "../styles/sessionDetailsArea.scss";
+import "../styles/SessionDetailsArea.scss";
 
 const getOpenButtonTitle = () => {
   const defaultBehavior = getSettings("openButtonBehavior");

--- a/src/popup/components/SessionItem.js
+++ b/src/popup/components/SessionItem.js
@@ -12,14 +12,17 @@ export default class Session extends Component {
   constructor(props) {
     super(props);
   }
+  
   render() {
-    const { session, isSelected, order, searchWord, handleSessionSelect } = this.props;
+    const { session, isSelected, order, searchWord, handleSessionSelect, handleKeyDown, previous, next } = this.props;
 
     return (
       <button
         className={`sessionItem ${isSelected ? "isSelected" : ""}`}
-        onClick={() => handleSessionSelect(session.id)}
+        onFocus={() => handleSessionSelect(session.id)}
+        onKeyDown={(event) => handleKeyDown(event, session, previous, next)}
         style={{ order: order }}
+        ref={(input) => { if (input && isSelected) input.focus(); }}
       >
         <span className={`name ${getSettings("truncateTitle") ? "isTruncate" : ""}`}>
           <Highlight search={searchWord}>

--- a/src/popup/components/TextInputModalContent.js
+++ b/src/popup/components/TextInputModalContent.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import browser from "webextension-polyfill";
-import "../styles/textInputModalContent.scss";
+import "../styles/TextInputModalContent.scss";
 
 export default class TextInputModalContent extends Component {
   constructor(props) {


### PR DESCRIPTION
It has been bothering me for some time that while I could open the extension with list of sessions by shortcut, I had to use mouse to actually select and open session, or go through numerous elements using TAB key. This code should allow selecting and opening of session using up/down/enter keys.

I'm neither reactjs nor javascript developer so the code may not be up to your standards, tough this functionality is something that would be nice to add.