### PR TITLE
Disable "Save the session" options by default

### DIFF
--- a/src/settings/defaultSettings.js
+++ b/src/settings/defaultSettings.js
@@ -110,7 +110,7 @@ export default [
         title: "ifAutoSaveLabel",
         captions: ["ifAutoSaveCaptionLabel"],
         type: "checkbox",
-        default: true,
+        default: false,
         childElements: [
           {
             id: "autoSaveInterval",
@@ -138,7 +138,7 @@ export default [
         title: "ifAutoSaveWhenCloseLabel",
         captions: ["ifAutoSaveWhenCloseCaptionLabel"],
         type: "checkbox",
-        default: true,
+        default: false,
         childElements: [
           {
             id: "autoSaveWhenCloseLimit",
@@ -156,7 +156,7 @@ export default [
         title: "ifAutoSaveWhenExitBrowserLabel",
         captions: ["ifAutoSaveWhenExitBrowserCaptionLabel"],
         type: "checkbox",
-        default: true,
+        default: false,
         childElements: [
           {
             id: "autoSaveWhenExitBrowserLimit",


### PR DESCRIPTION
Disable "Save the session regularly", "Save the session when window was closed" and "Save the session when exiting browser" options by default. Fixes https://github.com/sienori/Tab-Session-Manager/issues/502.