### PR TITLE
Import Firefox recovery.jsonlz4 / backup.jsonlz4 / sessionstore.jsonlz4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3752,6 +3752,11 @@
         "yallist": "^4.0.0"
       }
     },
+    "lz4js": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/lz4js/-/lz4js-0.2.0.tgz",
+      "integrity": "sha1-CfGjl8shWPZ1FGwzUd3oUFjLMi8="
+    },
     "make-dir": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
@@ -3997,6 +4002,14 @@
       "version": "2.24.0",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
       "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+    },
+    "mozlz4a": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mozlz4a/-/mozlz4a-1.1.0.tgz",
+      "integrity": "sha1-N7FUJBMg/DRtLww41ZwmzbV4tn0=",
+      "requires": {
+        "lz4js": ">=0.2.0"
+      }
     },
     "ms": {
       "version": "2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1893,6 +1893,12 @@
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
     },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -1942,6 +1948,16 @@
         "electron-to-chromium": "^1.3.723",
         "escalade": "^3.1.1",
         "node-releases": "^1.1.71"
+      }
+    },
+    "buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "buffer-crc32": {
@@ -3346,6 +3362,12 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
       "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
+      "dev": true
+    },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
       "dev": true
     },
     "ignore": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@babel/preset-react": "^7.9.4",
     "babel-loader": "^8.1.0",
     "babel-plugin-transform-class-properties": "^6.24.1",
+    "buffer": "^6.0.3",
     "clean-webpack-plugin": "^0.1.19",
     "copy-webpack-plugin": "^9.0.1",
     "css-loader": "^6.2.0",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lodash": "^4.17.21",
     "loglevel": "^1.6.7",
     "moment": "^2.24.0",
+    "mozlz4a": "^1.1.0",
     "prop-types": "^15.7.2",
     "query-string": "^6.11.1",
     "react": "^16.13.1",

--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -8,6 +8,7 @@ const {
   getCopyPlugins,
   getFirefoxCopyPlugins,
   getMiniCssExtractPlugin,
+  getBufferPlugin,
   getEntry
 } = require("./webpack.utils");
 const path = require("path");
@@ -79,7 +80,8 @@ module.exports = [
     plugins: [
       ...getMiniCssExtractPlugin(),
       ...getHTMLPlugins("chrome", config.devDirectory, config.chromePath),
-      ...getCopyPlugins("chrome", config.devDirectory, config.chromePath)
+      ...getCopyPlugins("chrome", config.devDirectory, config.chromePath),
+      ...getBufferPlugin(),
     ]
   },
   {
@@ -89,7 +91,8 @@ module.exports = [
     plugins: [
       ...getMiniCssExtractPlugin(),
       ...getFirefoxCopyPlugins("firefox", config.devDirectory, config.firefoxPath),
-      ...getHTMLPlugins("firefox", config.devDirectory, config.firefoxPath)
+      ...getHTMLPlugins("firefox", config.devDirectory, config.firefoxPath),
+      ...getBufferPlugin(),
     ]
   }
 ];

--- a/webpack.config.dist.js
+++ b/webpack.config.dist.js
@@ -11,6 +11,7 @@ const {
   getZipPlugin,
   getFirefoxCopyPlugins,
   getMiniCssExtractPlugin,
+  getBufferPlugin,
   getEntry
 } = require("./webpack.utils");
 const path = require("path");
@@ -90,7 +91,8 @@ module.exports = [
       ...getMiniCssExtractPlugin(),
       ...getHTMLPlugins("chrome", config.tempDirectory, config.chromePath),
       ...getCopyPlugins("chrome", config.tempDirectory, config.chromePath),
-      getZipPlugin(`${config.extName}-for-chrome-${extVersion}`, config.distDirectory)
+      getZipPlugin(`${config.extName}-for-chrome-${extVersion}`, config.distDirectory),
+      ...getBufferPlugin(),
     ]
   },
   {
@@ -105,7 +107,8 @@ module.exports = [
       ...getMiniCssExtractPlugin(),
       ...getHTMLPlugins("firefox", config.tempDirectory, config.firefoxPath),
       ...getFirefoxCopyPlugins("firefox", config.tempDirectory, config.firefoxPath),
-      getZipPlugin(`${config.extName}-for-firefox-${ffExtVersion}`, config.distDirectory)
+      getZipPlugin(`${config.extName}-for-firefox-${ffExtVersion}`, config.distDirectory),
+      ...getBufferPlugin(),
     ]
   },
   {

--- a/webpack.utils.js
+++ b/webpack.utils.js
@@ -8,6 +8,7 @@ const CopyWebpackPlugin = require("copy-webpack-plugin");
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const ZipPlugin = require("zip-webpack-plugin");
 const path = require("path");
+const webpack = require("webpack");
 
 const getHTMLPlugins = (browserDir, outputDir = "dev", sourceDir = "src") => [
   new HtmlWebpackPlugin({
@@ -113,12 +114,19 @@ const getZipPlugin = (browserDir, outputDir = "dist", exclude = "") =>
     exclude: exclude
   });
 
+const getBufferPlugin = () => [
+  new webpack.ProvidePlugin({
+    Buffer: [require.resolve("buffer/"), "Buffer"],
+  }),
+];
+
 module.exports = {
   getHTMLPlugins,
   getOutput,
   getCopyPlugins,
   getFirefoxCopyPlugins,
   getMiniCssExtractPlugin,
+  getBufferPlugin,
   getZipPlugin,
   getEntry
 };


### PR DESCRIPTION
When Firefox crashes, sometimes it does not open the previous session, even when correctly copying the session backup to sessionstore.jsonlz4.
If Tab-Session-Manager was not loaded at the time of the crash, then it can be difficult to manually recover the session.

This change adds support for importing Firefox session backups into Tab-Session-Manager.

Tree Style Tab data is available in the session backup, so it should be possible to import that data too, but this change does not import it.