### PR TITLE
Fix Firefox sessionstore import when the session has unloaded tabs

### DIFF
--- a/src/options/components/ImportSessionsComponent.js
+++ b/src/options/components/ImportSessionsComponent.js
@@ -207,16 +207,30 @@ const convertMozLz4Sessionstore = async file => {
     let index = 0;
     for (const tab of mozSession.windows[win].tabs) {
       const entryIndex = tab.index - 1;
-      session.windows[win][index] = {
-        id: index,
-        index: index,
-        windowId: parseInt(win, 10),
-        lastAccessed: tab.lastAccessed,
-        url: tab.entries[entryIndex].url,
-        title: tab.entries[entryIndex].title,
-        favIconUrl: tab.image,
-        discarded: true,
-      };
+      if (tab.entries[entryIndex]) {
+        session.windows[win][index] = {
+          id: index,
+          index: index,
+          windowId: parseInt(win, 10),
+          lastAccessed: tab.lastAccessed,
+          url: tab.entries[entryIndex].url,
+          title: tab.entries[entryIndex].title,
+          favIconUrl: tab.image,
+          discarded: true,
+        };
+      } else {
+        // User typed value into URL bar but page was not loaded
+        session.windows[win][index] = {
+          id: index,
+          index: index,
+          windowId: parseInt(win, 10),
+          lastAccessed: tab.lastAccessed,
+          url: 'about:blank#' + tab.userTypedValue,
+          title: 'New Tab',
+          favIconUrl: tab.image,
+          discarded: true,
+        };
+      }
       index++;
     }
     session.tabsNumber += index;

--- a/src/options/components/ImportSessionsComponent.js
+++ b/src/options/components/ImportSessionsComponent.js
@@ -210,7 +210,7 @@ const convertMozLz4Sessionstore = async file => {
       session.windows[win][index] = {
         id: index,
         index: index,
-        windowId: parseInt(win),
+        windowId: parseInt(win, 10),
         lastAccessed: tab.lastAccessed,
         url: tab.entries[entryIndex].url,
         title: tab.entries[entryIndex].title,


### PR DESCRIPTION
When a Firefox session has an unloaded tab with a user-typed value in the URL bar, there is a tab object, but no objects in the tab entries.
Previously, this would cause the session import to fail.
This change adds a check for tab entries, and if there is no entry, it creates a placeholder about:blank tab containing the user-typed value in the hash part of the URL.