### PR TITLE
Grammar: "windows position" -> "window's position"

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -285,10 +285,10 @@
     "message": "The favicon of the lazy loading tab is not displayed."
   },
   "isRestoreWindowPositionLabel": {
-    "message": "Restore windows position"
+    "message": "Restore window's position"
   },
   "isRestoreWindowPositionCaptionLabel": {
-    "message": "Restore windows position and size when opening session."
+    "message": "Restore window's position and size when opening session."
   },
   "startupLabel": {
     "message": "Startup"


### PR DESCRIPTION
Or perhaps plural "windows' positions" fits better?