### PR TITLE
add content_security_policy

### DIFF
--- a/src/manifest-ff.json
+++ b/src/manifest-ff.json
@@ -9,6 +9,7 @@
       "id": "Tab-Session-Manager@sienori"
     }
   },
+  "content_security_policy": "default-src 'none'; script-src 'self'; object-src 'self'; connect-src 'none';",
   "permissions": [
     "storage",
     "unlimitedStorage",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -4,6 +4,7 @@
   "name": "__MSG_extName__",
   "description": "__MSG_extDescription__",
   "default_locale": "en",
+  "content_security_policy": "default-src 'none'; script-src 'self'; object-src 'self'; connect-src 'none';",
   "permissions": [
     "storage",
     "unlimitedStorage",


### PR DESCRIPTION
This just adds content-security-policy to Chrome and Firefox manifest which should decrease risk score on https://crxcavator.io/report/iaiomicjabeggjcfkbimgmglanimpnae

I believe there is no XMLHTTPRequest which would need connect-src.