### PR TITLE
Replace deprecated String.prototype.substr()

### DIFF
--- a/src/background/open.js
+++ b/src/background/open.js
@@ -247,7 +247,7 @@ function openTab(tab, currentWindow, isOpenToLastIndex = false) {
     }
 
     //Reader mode
-    if (tab.url.substr(0, 17) == "about:reader?url=") {
+    if (tab.url.startsWith("about:reader?url=")) {
       if (getSettings("ifLazyLoading")) {
         createOption.url = returnReplaceURL(
           "redirect",
@@ -257,7 +257,7 @@ function openTab(tab, currentWindow, isOpenToLastIndex = false) {
         );
       } else {
         if (isEnabledOpenInReaderMode) createOption.openInReaderMode = true;
-        createOption.url = decodeURIComponent(tab.url.substr(17));
+        createOption.url = decodeURIComponent(tab.url.slice(17));
       }
     }
 

--- a/src/background/replace.js
+++ b/src/background/replace.js
@@ -37,7 +37,7 @@ export function returnReplaceURL(state, title, url, favIconUrl) {
     theme;
 
   //Reader mode
-  if (url.substr(0, 17) == "about:reader?url=") {
+  if (url.startsWith("about:reader?url=")) {
     retUrl =
       "replaced/index.html" +
       "?state=" +
@@ -45,7 +45,7 @@ export function returnReplaceURL(state, title, url, favIconUrl) {
       "&title=" +
       encodeURIComponent(title) +
       "&url=" +
-      url.substr(17) +
+      url.slice(17) +
       "&favIconUrl=" +
       encodeURIComponent(favIconUrl) +
       "&openInReaderMode=true" +

--- a/src/options/components/ImportSessionsComponent.js
+++ b/src/options/components/ImportSessionsComponent.js
@@ -29,7 +29,7 @@ const fileOpen = file => {
       let text = reader.result;
       if (file.name.toLowerCase().endsWith(".json")) {
         // Ignore BOM
-        if (text.charCodeAt(0) === 0xFEFF) text = text.substr(1);
+        if (text.charCodeAt(0) === 0xFEFF) text = text.slice(1);
         if (!isJSON(text)) return resolve();
 
         let jsonFile = JSON.parse(text);
@@ -152,11 +152,11 @@ const convertSessionManager = file => {
   session.windows = {};
   session.windowsNumber = 0;
   session.tabsNumber = 0;
-  session.name = line[1].substr(5);
-  session.date = moment(parseInt(line[2].substr(10))).valueOf();
+  session.name = line[1].slice(5);
+  session.date = moment(parseInt(line[2].slice(10))).valueOf();
   session.lastEditedTime = Date.now();
   session.tag = [];
-  session.sessionStartTime = parseInt(line[2].substr(10));
+  session.sessionStartTime = parseInt(line[2].slice(10));
   session.id = uuidv4();
 
   if (!isJSON(line[4])) return;


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with functions which aren't.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.