### PR TITLE
Fixed save error while using PWA and enabled save tab groups (#981)

### DIFF
--- a/src/background/save.js
+++ b/src/background/save.js
@@ -82,8 +82,12 @@ export async function loadCurrentSession(name, tag, property) {
   }
 
   if (isEnabledTabGroups && getSettings("saveTabGroups")) {
-    const tabGroups = await queryTabGroups();
-    const filteredTabGroups = tabGroups.filter(tabGroup =>
+    // ポップアップやPWAにはタブ自体が存在しないので、normalタイプのウィンドウのみクエリする
+    const filteredWindows = Object.values(session.windowsInfo).filter(window => window.type === "normal");
+    const tabGroups = await Promise.all(filteredWindows.map(window => queryTabGroups({
+      windowId: window.id,
+    })));
+    const filteredTabGroups = tabGroups.flat().filter(tabGroup =>
       Object.keys(session.windows).includes(String(tabGroup.windowId)));
     if (filteredTabGroups.length > 0) session.tabGroups = filteredTabGroups;
   }


### PR DESCRIPTION
This PR fixes a save error in Chrome 100 (probably *1) or later when enabled save tab groups and opening PWA.
I commenting in Japanese because the code contains Japanese comments, but feel free to tell me if you want to make them in English.

*1 https://www.reddit.com/r/chrome_extensions/comments/ujzhqp/anyone_came_across_this_exception_in_a_chrome/

----

## Original errors

### Tab Session Manager

![image](https://user-images.githubusercontent.com/5028163/188279439-a0fbfab5-1997-4a36-a72e-9758bd69fd31.png)

### Save Tab Groups for Tab Session Manager

![image](https://user-images.githubusercontent.com/5028163/188279458-90c6aba3-0aef-4222-9996-0810d4326a44.png)

## Applied this PR

Temporary added some logs (not include this PR).

![image](https://user-images.githubusercontent.com/5028163/188279476-810f0364-1834-429c-8e22-f972a66c7398.png)