### PR TITLE
fix: cannot open the session when window and monitor intersect in a meaningless way

### DIFF
--- a/src/background/open.js
+++ b/src/background/open.js
@@ -44,8 +44,23 @@ export async function openSession(session, property = "openInNewWindow") {
             break;
         }
       }
-
-      const currentWindow = await browser.windows.create(createData);
+      let currentWindow
+      try {
+        currentWindow = await browser.windows.create(createData);
+      } catch (e) {
+        /**
+         * @see https://source.chromium.org/chromium/chromium/src/+/d51682b36adc22496f45a8111358a8bb30914534
+         * @see https://github.com/sienori/Tab-Session-Manager/issues/1057
+         * try to open a window in "safe" mode
+         */
+        currentWindow = await browser.windows.create({
+          ...createData,
+          width: 800,
+          height: 600,
+          top: 0,
+          left: 0,
+        });
+      }
 
       if (isSetPosition && session.windowsInfo[win].state == "maximized") {
         browser.windows.update(currentWindow.id, { state: "maximized" });


### PR DESCRIPTION
see #1057, i fixed it.

Reference https://source.chromium.org/chromium/chromium/src/+/d51682b36adc22496f45a8111358a8bb30914534

I tested the problem in my local area and the previously unopenable session would open normally in "safe" mode, while the behavior of the other openable sessions was unaffected.