### PR TITLE
DIsable autosave for only one tab in a window

### DIFF
--- a/src/background/autoSave.js
+++ b/src/background/autoSave.js
@@ -135,7 +135,8 @@ export const autoSaveWhenWindowClose = async removedWindowId => {
   session.id = uuidv4();
   session.windowsNumber = 1;
   session.tabsNumber = Object.keys(session.windows[removedWindowId]).length;
-  if(session.tabsNumber!=1)
+  
+  if (session.tabsNumber != 1)
   await saveSession(session);
 
   const limit = getSettings("autoSaveWhenCloseLimit");

--- a/src/background/autoSave.js
+++ b/src/background/autoSave.js
@@ -135,7 +135,7 @@ export const autoSaveWhenWindowClose = async removedWindowId => {
   session.id = uuidv4();
   session.windowsNumber = 1;
   session.tabsNumber = Object.keys(session.windows[removedWindowId]).length;
-  
+
   if (session.tabsNumber != 1)
   await saveSession(session);
 

--- a/src/background/autoSave.js
+++ b/src/background/autoSave.js
@@ -135,7 +135,7 @@ export const autoSaveWhenWindowClose = async removedWindowId => {
   session.id = uuidv4();
   session.windowsNumber = 1;
   session.tabsNumber = Object.keys(session.windows[removedWindowId]).length;
-
+  if(session.tabsNumber!=1)
   await saveSession(session);
 
   const limit = getSettings("autoSaveWhenCloseLimit");


### PR DESCRIPTION
Fixes #1094 
While using this extension for tracking the window changes one problem I faced was If I am opening an new window and in it open a single tab and close it, It gets tracked which is already done by the browser itself.

Therefore I have added a condition where I am checking the no of tabs while saving in the closed window menu.