### PR TITLE
Ignore lazy tab loading list settings

### DIFF
--- a/src/background/ignoreUrls.js
+++ b/src/background/ignoreUrls.js
@@ -6,7 +6,7 @@ import { deleteTab } from "src/common/editSessions";
 
 const logDir = "background/ignoreUrls";
 
-const matchesPageUrl = (pageUrl, urlPattern) => {
+export const matchesPageUrl = (pageUrl, urlPattern) => {
   const pattern = urlPattern
     .trim()
     .replace(/[-[\]{}()*+?.,\\^$|#\s]/g, match => (match === "*" ? ".*" : "\\" + match));

--- a/src/background/open.js
+++ b/src/background/open.js
@@ -249,7 +249,7 @@ function openTab(tab, currentWindow, isOpenToLastIndex = false) {
     }
 
     //Lazy loading
-    if (getSettings("ifLazyLoading") && matchesPageUrl(tab.url,getSettings("ignoreLazyLoadingUrls"))) {
+    if (getSettings("ifLazyLoading") && !matchesPageUrl(tab.url,getSettings("ignoreLazyLoadingUrls"))) {
       if (getSettings("isUseDiscarded") && isEnabledDiscarded) {
         if (!createOption.active && !createOption.pinned) {
           createOption.discarded = true;

--- a/src/background/open.js
+++ b/src/background/open.js
@@ -2,6 +2,7 @@ import browser from "webextension-polyfill";
 import browserInfo from "browser-info";
 import log from "loglevel";
 import { getSettings } from "src/settings/settings";
+import { matchesPageUrl } from "./ignoreUrls.js";
 import { returnReplaceURL, replacePage } from "./replace.js";
 import { updateTabGroups } from "../common/tabGroups";
 import { isTrackingSession, startTracking } from "./track.js";
@@ -248,7 +249,7 @@ function openTab(tab, currentWindow, isOpenToLastIndex = false) {
     }
 
     //Lazy loading
-    if (getSettings("ifLazyLoading")) {
+    if (getSettings("ifLazyLoading") && matchesPageUrl(tab.url,getSettings("ignoreLazyLoadingUrls"))) {
       if (getSettings("isUseDiscarded") && isEnabledDiscarded) {
         if (!createOption.active && !createOption.pinned) {
           createOption.discarded = true;

--- a/src/settings/defaultSettings.js
+++ b/src/settings/defaultSettings.js
@@ -33,6 +33,14 @@ export default [
         ]
       },
       {
+        id: "ignoreLazyLoadingUrls",
+        title: "ignoreLazyLoadingUrlsLabel",
+        captions: ["ignoreLazyLoadingUrlsCaptionLabel"],
+        type: "textarea",
+        default: "",
+        placeholder: "https://example.com/*\nhttps://example.net/*"
+      },
+      {
         id: "isRestoreWindowPosition",
         title: "isRestoreWindowPositionLabel",
         captions: ["isRestoreWindowPositionCaptionLabel"],


### PR DESCRIPTION
Fixes #1101 
Added option and logic for ignoring lazy loading for some selected tabs in the list.

![image](https://user-images.githubusercontent.com/76404817/198742080-c042f0fc-a7ee-4ffb-ba7f-162edf75215b.png)
