### PR TITLE
remove unneeded requires from legacy library

### DIFF
--- a/src/common/editSessions.js
+++ b/src/common/editSessions.js
@@ -2,7 +2,6 @@ import browser from "webextension-polyfill";
 import _ from "lodash";
 import clone from "clone";
 import log from "loglevel";
-import "core-js/fn/array/flat-map";
 
 const logDir = "common/editSessions";
 

--- a/src/popup/actions/controlSessions.js
+++ b/src/popup/actions/controlSessions.js
@@ -4,7 +4,6 @@ import _ from "lodash";
 import uuidv4 from "uuid/v4";
 import moment from "moment";
 import log from "loglevel";
-import "core-js/fn/array/flat-map";
 import { returnReplaceParameter } from "src/background/replace.js";
 import { queryTabGroups } from "../../common/tabGroups";
 import { getSettings } from "src/settings/settings";


### PR DESCRIPTION
These 'requires' imports prevented a build on my system, and don't seem to be needed.

(Not a JS person, was investigating a weird error with autosave not working, which wound up being a corrupted database entry fixed by uninstalling/reinstalling the extension).