### PR TITLE
Fix Tracking Multiple Sessions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1860,7 +1860,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.3",
-              "resolved": "",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.3.tgz",
+              "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw==",
               "dev": true
             }
           }
@@ -7326,7 +7327,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.3",
-              "resolved": ""
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.3.tgz",
+              "integrity": "sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw=="
             }
           }
         },

--- a/src/_locales/af/messages.json
+++ b/src/_locales/af/messages.json
@@ -329,6 +329,12 @@
   "shouldTrackNewWindowCaptionLabel": {
     "message": "When a new window is opened within a tracking session, include it in the tracking."
   },
+  "shouldTrackDeletedWindowsLabel": {
+    "message": "Remove closed windows from saved sessions"
+  },
+  "shouldTrackDeletedWindowsCaptionLabel": {
+    "message": "When a window is closed within a tracking session, remove it from the tracked session."
+  },
   "ifAutoSaveLabel": {
     "message": "Save the session regularly"
   },

--- a/src/_locales/ar/messages.json
+++ b/src/_locales/ar/messages.json
@@ -329,6 +329,12 @@
   "shouldTrackNewWindowCaptionLabel": {
     "message": "When a new window is opened within a tracking session, include it in the tracking."
   },
+  "shouldTrackDeletedWindowsLabel": {
+    "message": "Remove closed windows from saved sessions"
+  },
+  "shouldTrackDeletedWindowsCaptionLabel": {
+    "message": "When a window is closed within a tracking session, remove it from the tracked session."
+  },
   "ifAutoSaveLabel": {
     "message": "احفظ الجلسة بإنتظام"
   },

--- a/src/_locales/bg/messages.json
+++ b/src/_locales/bg/messages.json
@@ -329,6 +329,12 @@
   "shouldTrackNewWindowCaptionLabel": {
     "message": "Когато се отвори нов прозорец в рамките на сесия за проследяване, включете го в проследяването."
   },
+  "shouldTrackDeletedWindowsLabel": {
+    "message": "Remove closed windows from saved sessions"
+  },
+  "shouldTrackDeletedWindowsCaptionLabel": {
+    "message": "When a window is closed within a tracking session, remove it from the tracked session."
+  },
   "ifAutoSaveLabel": {
     "message": "Редовно запазване на сесията"
   },

--- a/src/_locales/ca/messages.json
+++ b/src/_locales/ca/messages.json
@@ -329,6 +329,12 @@
   "shouldTrackNewWindowCaptionLabel": {
     "message": "When a new window is opened within a tracking session, include it in the tracking."
   },
+  "shouldTrackDeletedWindowsLabel": {
+    "message": "Remove closed windows from saved sessions"
+  },
+  "shouldTrackDeletedWindowsCaptionLabel": {
+    "message": "When a window is closed within a tracking session, remove it from the tracked session."
+  },
   "ifAutoSaveLabel": {
     "message": "Save the session regularly"
   },

--- a/src/_locales/cs/messages.json
+++ b/src/_locales/cs/messages.json
@@ -329,6 +329,12 @@
   "shouldTrackNewWindowCaptionLabel": {
     "message": "Když je v rámci sledovací relace otevřeno nové okno, přidejte ho do sledování."
   },
+  "shouldTrackDeletedWindowsLabel": {
+    "message": "Remove closed windows from saved sessions"
+  },
+  "shouldTrackDeletedWindowsCaptionLabel": {
+    "message": "When a window is closed within a tracking session, remove it from the tracked session."
+  },
   "ifAutoSaveLabel": {
     "message": "Ukládat relaci pravidelně"
   },

--- a/src/_locales/da/messages.json
+++ b/src/_locales/da/messages.json
@@ -329,6 +329,12 @@
   "shouldTrackNewWindowCaptionLabel": {
     "message": "When a new window is opened within a tracking session, include it in the tracking."
   },
+  "shouldTrackDeletedWindowsLabel": {
+    "message": "Remove closed windows from saved sessions"
+  },
+  "shouldTrackDeletedWindowsCaptionLabel": {
+    "message": "When a window is closed within a tracking session, remove it from the tracked session."
+  },
   "ifAutoSaveLabel": {
     "message": "Save the session regularly"
   },

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -329,6 +329,12 @@
   "shouldTrackNewWindowCaptionLabel": {
     "message": "Neues Fenster zur Verfolgung hinzufügen, falls es innerhalb einer Verfolgungs-Sitzung geöffnet wird."
   },
+  "shouldTrackDeletedWindowsLabel": {
+    "message": "Remove closed windows from saved sessions"
+  },
+  "shouldTrackDeletedWindowsCaptionLabel": {
+    "message": "When a window is closed within a tracking session, remove it from the tracked session."
+  },
   "ifAutoSaveLabel": {
     "message": "Sitzung regelmäßig sichern"
   },

--- a/src/_locales/el/messages.json
+++ b/src/_locales/el/messages.json
@@ -329,6 +329,12 @@
   "shouldTrackNewWindowCaptionLabel": {
     "message": "Όταν ανοίγει ένα νέο παράθυρο μέσα σε μια συνεδρία παρακολούθησης, συμπεριλάβετέ το στην παρακολούθηση."
   },
+  "shouldTrackDeletedWindowsLabel": {
+    "message": "Remove closed windows from saved sessions"
+  },
+  "shouldTrackDeletedWindowsCaptionLabel": {
+    "message": "When a window is closed within a tracking session, remove it from the tracked session."
+  },
   "ifAutoSaveLabel": {
     "message": "Τακτική αποθήκευση συνεδρίας"
   },

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -329,6 +329,12 @@
   "shouldTrackNewWindowCaptionLabel": {
     "message": "When a new window is opened within a tracking session, include it in the tracking."
   },
+  "shouldTrackDeletedWindowsLabel": {
+    "message": "Remove closed windows from saved sessions"
+  },
+  "shouldTrackDeletedWindowsCaptionLabel": {
+    "message": "When a window is closed within a tracking session, remove it from the tracked session."
+  },
   "ifAutoSaveLabel": {
     "message": "Save the session regularly"
   },

--- a/src/_locales/es/messages.json
+++ b/src/_locales/es/messages.json
@@ -329,6 +329,12 @@
   "shouldTrackNewWindowCaptionLabel": {
     "message": "When a new window is opened within a tracking session, include it in the tracking."
   },
+  "shouldTrackDeletedWindowsLabel": {
+    "message": "Remove closed windows from saved sessions"
+  },
+  "shouldTrackDeletedWindowsCaptionLabel": {
+    "message": "When a window is closed within a tracking session, remove it from the tracked session."
+  },
   "ifAutoSaveLabel": {
     "message": "Guardar la sesión regularmente"
   },

--- a/src/_locales/fi/messages.json
+++ b/src/_locales/fi/messages.json
@@ -329,6 +329,12 @@
   "shouldTrackNewWindowCaptionLabel": {
     "message": "When a new window is opened within a tracking session, include it in the tracking."
   },
+  "shouldTrackDeletedWindowsLabel": {
+    "message": "Remove closed windows from saved sessions"
+  },
+  "shouldTrackDeletedWindowsCaptionLabel": {
+    "message": "When a window is closed within a tracking session, remove it from the tracked session."
+  },
   "ifAutoSaveLabel": {
     "message": "Tallenna istunto säännöllisesti"
   },

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -329,6 +329,12 @@
   "shouldTrackNewWindowCaptionLabel": {
     "message": "Lorsqu’une nouvelle fenêtre est ouverte dans une session surveillée, l’inclure dans la surveillance."
   },
+  "shouldTrackDeletedWindowsLabel": {
+    "message": "Remove closed windows from saved sessions"
+  },
+  "shouldTrackDeletedWindowsCaptionLabel": {
+    "message": "When a window is closed within a tracking session, remove it from the tracked session."
+  },
   "ifAutoSaveLabel": {
     "message": "Enregistrer régulièrement la session"
   },

--- a/src/_locales/he/messages.json
+++ b/src/_locales/he/messages.json
@@ -329,6 +329,12 @@
   "shouldTrackNewWindowCaptionLabel": {
     "message": "When a new window is opened within a tracking session, include it in the tracking."
   },
+  "shouldTrackDeletedWindowsLabel": {
+    "message": "Remove closed windows from saved sessions"
+  },
+  "shouldTrackDeletedWindowsCaptionLabel": {
+    "message": "When a window is closed within a tracking session, remove it from the tracked session."
+  },
   "ifAutoSaveLabel": {
     "message": "שמור את הפעילות באופן קבוע"
   },

--- a/src/_locales/hi/messages.json
+++ b/src/_locales/hi/messages.json
@@ -329,6 +329,12 @@
   "shouldTrackNewWindowCaptionLabel": {
     "message": "When a new window is opened within a tracking session, include it in the tracking."
   },
+  "shouldTrackDeletedWindowsLabel": {
+    "message": "Remove closed windows from saved sessions"
+  },
+  "shouldTrackDeletedWindowsCaptionLabel": {
+    "message": "When a window is closed within a tracking session, remove it from the tracked session."
+  },
   "ifAutoSaveLabel": {
     "message": "सत्र को नियमित रूप से सहेजें"
   },

--- a/src/_locales/hu/messages.json
+++ b/src/_locales/hu/messages.json
@@ -329,6 +329,12 @@
   "shouldTrackNewWindowCaptionLabel": {
     "message": "Ha új ablak nyílt a követés munkamenetben, kövessük azt is."
   },
+  "shouldTrackDeletedWindowsLabel": {
+    "message": "Remove closed windows from saved sessions"
+  },
+  "shouldTrackDeletedWindowsCaptionLabel": {
+    "message": "When a window is closed within a tracking session, remove it from the tracked session."
+  },
   "ifAutoSaveLabel": {
     "message": "Munkamenet rendszeres mentése"
   },

--- a/src/_locales/id/messages.json
+++ b/src/_locales/id/messages.json
@@ -329,6 +329,12 @@
   "shouldTrackNewWindowCaptionLabel": {
     "message": "When a new window is opened within a tracking session, include it in the tracking."
   },
+  "shouldTrackDeletedWindowsLabel": {
+    "message": "Remove closed windows from saved sessions"
+  },
+  "shouldTrackDeletedWindowsCaptionLabel": {
+    "message": "When a window is closed within a tracking session, remove it from the tracked session."
+  },
   "ifAutoSaveLabel": {
     "message": "Simpan sesi secara berkala"
   },

--- a/src/_locales/it/messages.json
+++ b/src/_locales/it/messages.json
@@ -329,6 +329,12 @@
   "shouldTrackNewWindowCaptionLabel": {
     "message": "Quando una nuova finestra viene aperta all'interno di una sessione monitorata, includila nel monitoraggio."
   },
+  "shouldTrackDeletedWindowsLabel": {
+    "message": "Remove closed windows from saved sessions"
+  },
+  "shouldTrackDeletedWindowsCaptionLabel": {
+    "message": "When a window is closed within a tracking session, remove it from the tracked session."
+  },
   "ifAutoSaveLabel": {
     "message": "Salva la sessione regolarmente"
   },

--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -329,6 +329,12 @@
   "shouldTrackNewWindowCaptionLabel": {
     "message": "トラッキングセッション内で新しいウィンドウが開かれた場合、トラッキングの対象に含めます。"
   },
+  "shouldTrackDeletedWindowsLabel": {
+    "message": "Remove closed windows from saved sessions"
+  },
+  "shouldTrackDeletedWindowsCaptionLabel": {
+    "message": "When a window is closed within a tracking session, remove it from the tracked session."
+  },
   "ifAutoSaveLabel": {
     "message": "定期的にセッションを保存する"
   },

--- a/src/_locales/ko/messages.json
+++ b/src/_locales/ko/messages.json
@@ -329,6 +329,12 @@
   "shouldTrackNewWindowCaptionLabel": {
     "message": "When a new window is opened within a tracking session, include it in the tracking."
   },
+  "shouldTrackDeletedWindowsLabel": {
+    "message": "Remove closed windows from saved sessions"
+  },
+  "shouldTrackDeletedWindowsCaptionLabel": {
+    "message": "When a window is closed within a tracking session, remove it from the tracked session."
+  },
   "ifAutoSaveLabel": {
     "message": "주기적으로 세션 자동 저장"
   },

--- a/src/_locales/lv/messages.json
+++ b/src/_locales/lv/messages.json
@@ -329,6 +329,12 @@
   "shouldTrackNewWindowCaptionLabel": {
     "message": "When a new window is opened within a tracking session, include it in the tracking."
   },
+  "shouldTrackDeletedWindowsLabel": {
+    "message": "Remove closed windows from saved sessions"
+  },
+  "shouldTrackDeletedWindowsCaptionLabel": {
+    "message": "When a window is closed within a tracking session, remove it from the tracked session."
+  },
   "ifAutoSaveLabel": {
     "message": "Save the session regularly"
   },

--- a/src/_locales/nl/messages.json
+++ b/src/_locales/nl/messages.json
@@ -329,6 +329,12 @@
   "shouldTrackNewWindowCaptionLabel": {
     "message": "When a new window is opened within a tracking session, include it in the tracking."
   },
+  "shouldTrackDeletedWindowsLabel": {
+    "message": "Remove closed windows from saved sessions"
+  },
+  "shouldTrackDeletedWindowsCaptionLabel": {
+    "message": "When a window is closed within a tracking session, remove it from the tracked session."
+  },
   "ifAutoSaveLabel": {
     "message": "Sla de sessie regelmatig op"
   },

--- a/src/_locales/no/messages.json
+++ b/src/_locales/no/messages.json
@@ -329,6 +329,12 @@
   "shouldTrackNewWindowCaptionLabel": {
     "message": "Ta med nye vindauge når dei vert opna inni ei sporingsøkt."
   },
+  "shouldTrackDeletedWindowsLabel": {
+    "message": "Remove closed windows from saved sessions"
+  },
+  "shouldTrackDeletedWindowsCaptionLabel": {
+    "message": "When a window is closed within a tracking session, remove it from the tracked session."
+  },
   "ifAutoSaveLabel": {
     "message": "Lagra økta jamnleg"
   },

--- a/src/_locales/pl/messages.json
+++ b/src/_locales/pl/messages.json
@@ -329,6 +329,12 @@
   "shouldTrackNewWindowCaptionLabel": {
     "message": "When a new window is opened within a tracking session, include it in the tracking."
   },
+  "shouldTrackDeletedWindowsLabel": {
+    "message": "Remove closed windows from saved sessions"
+  },
+  "shouldTrackDeletedWindowsCaptionLabel": {
+    "message": "When a window is closed within a tracking session, remove it from the tracked session."
+  },
   "ifAutoSaveLabel": {
     "message": "Zapisuj sesję regularnie"
   },

--- a/src/_locales/pt/messages.json
+++ b/src/_locales/pt/messages.json
@@ -329,6 +329,12 @@
   "shouldTrackNewWindowCaptionLabel": {
     "message": "When a new window is opened within a tracking session, include it in the tracking."
   },
+  "shouldTrackDeletedWindowsLabel": {
+    "message": "Remove closed windows from saved sessions"
+  },
+  "shouldTrackDeletedWindowsCaptionLabel": {
+    "message": "When a window is closed within a tracking session, remove it from the tracked session."
+  },
   "ifAutoSaveLabel": {
     "message": "Salvar a sessão regularmente"
   },

--- a/src/_locales/ro/messages.json
+++ b/src/_locales/ro/messages.json
@@ -329,6 +329,12 @@
   "shouldTrackNewWindowCaptionLabel": {
     "message": "When a new window is opened within a tracking session, include it in the tracking."
   },
+  "shouldTrackDeletedWindowsLabel": {
+    "message": "Remove closed windows from saved sessions"
+  },
+  "shouldTrackDeletedWindowsCaptionLabel": {
+    "message": "When a window is closed within a tracking session, remove it from the tracked session."
+  },
   "ifAutoSaveLabel": {
     "message": "Salvează sesiunea în mod regulat"
   },

--- a/src/_locales/ru/messages.json
+++ b/src/_locales/ru/messages.json
@@ -329,6 +329,12 @@
   "shouldTrackNewWindowCaptionLabel": {
     "message": "Когда во время работы сессии отслеживания открывается новое окно, отслеживать его тоже."
   },
+  "shouldTrackDeletedWindowsLabel": {
+    "message": "Remove closed windows from saved sessions"
+  },
+  "shouldTrackDeletedWindowsCaptionLabel": {
+    "message": "When a window is closed within a tracking session, remove it from the tracked session."
+  },
   "ifAutoSaveLabel": {
     "message": "Периодически сохранять сессию"
   },

--- a/src/_locales/si/messages.json
+++ b/src/_locales/si/messages.json
@@ -329,6 +329,12 @@
   "shouldTrackNewWindowCaptionLabel": {
     "message": "ලුහුබැඳීමේ සැසියක් තුළ නව කවුළුවක් විවෘත කළ විට, එය ලුහුබැඳීම තුළ ඇතුළත් කරන්න."
   },
+  "shouldTrackDeletedWindowsLabel": {
+    "message": "Remove closed windows from saved sessions"
+  },
+  "shouldTrackDeletedWindowsCaptionLabel": {
+    "message": "When a window is closed within a tracking session, remove it from the tracked session."
+  },
   "ifAutoSaveLabel": {
     "message": "සැසිය නිතිපතා සුරකින්න"
   },

--- a/src/_locales/sr/messages.json
+++ b/src/_locales/sr/messages.json
@@ -329,6 +329,12 @@
   "shouldTrackNewWindowCaptionLabel": {
     "message": "When a new window is opened within a tracking session, include it in the tracking."
   },
+  "shouldTrackDeletedWindowsLabel": {
+    "message": "Remove closed windows from saved sessions"
+  },
+  "shouldTrackDeletedWindowsCaptionLabel": {
+    "message": "When a window is closed within a tracking session, remove it from the tracked session."
+  },
   "ifAutoSaveLabel": {
     "message": "Save the session regularly"
   },

--- a/src/_locales/sv/messages.json
+++ b/src/_locales/sv/messages.json
@@ -329,6 +329,12 @@
   "shouldTrackNewWindowCaptionLabel": {
     "message": "När ett nytt fönster öppnas inom en spårningssession, inkludera det i spårningen."
   },
+  "shouldTrackDeletedWindowsLabel": {
+    "message": "Remove closed windows from saved sessions"
+  },
+  "shouldTrackDeletedWindowsCaptionLabel": {
+    "message": "When a window is closed within a tracking session, remove it from the tracked session."
+  },
   "ifAutoSaveLabel": {
     "message": "Spara sessionen regelbundet"
   },

--- a/src/_locales/tr/messages.json
+++ b/src/_locales/tr/messages.json
@@ -329,6 +329,12 @@
   "shouldTrackNewWindowCaptionLabel": {
     "message": "When a new window is opened within a tracking session, include it in the tracking."
   },
+  "shouldTrackDeletedWindowsLabel": {
+    "message": "Remove closed windows from saved sessions"
+  },
+  "shouldTrackDeletedWindowsCaptionLabel": {
+    "message": "When a window is closed within a tracking session, remove it from the tracked session."
+  },
   "ifAutoSaveLabel": {
     "message": "Oturumu düzenli olarak kaydet"
   },

--- a/src/_locales/uk/messages.json
+++ b/src/_locales/uk/messages.json
@@ -329,6 +329,12 @@
   "shouldTrackNewWindowCaptionLabel": {
     "message": "When a new window is opened within a tracking session, include it in the tracking."
   },
+  "shouldTrackDeletedWindowsLabel": {
+    "message": "Remove closed windows from saved sessions"
+  },
+  "shouldTrackDeletedWindowsCaptionLabel": {
+    "message": "When a window is closed within a tracking session, remove it from the tracked session."
+  },
   "ifAutoSaveLabel": {
     "message": "Періодично зберігати сесію"
   },

--- a/src/_locales/vi/messages.json
+++ b/src/_locales/vi/messages.json
@@ -329,6 +329,12 @@
   "shouldTrackNewWindowCaptionLabel": {
     "message": "When a new window is opened within a tracking session, include it in the tracking."
   },
+  "shouldTrackDeletedWindowsLabel": {
+    "message": "Remove closed windows from saved sessions"
+  },
+  "shouldTrackDeletedWindowsCaptionLabel": {
+    "message": "When a window is closed within a tracking session, remove it from the tracked session."
+  },
   "ifAutoSaveLabel": {
     "message": "Lưu lại phiên làm việc thường xuyên"
   },

--- a/src/_locales/zh_CN/messages.json
+++ b/src/_locales/zh_CN/messages.json
@@ -329,6 +329,12 @@
   "shouldTrackNewWindowCaptionLabel": {
     "message": "When a new window is opened within a tracking session, include it in the tracking."
   },
+  "shouldTrackDeletedWindowsLabel": {
+    "message": "Remove closed windows from saved sessions"
+  },
+  "shouldTrackDeletedWindowsCaptionLabel": {
+    "message": "When a window is closed within a tracking session, remove it from the tracked session."
+  },
   "ifAutoSaveLabel": {
     "message": "定期保存会话"
   },

--- a/src/_locales/zh_TW/messages.json
+++ b/src/_locales/zh_TW/messages.json
@@ -329,6 +329,12 @@
   "shouldTrackNewWindowCaptionLabel": {
     "message": "在已追蹤的瀏覽階段中開啟新視窗時，將新開的視窗加入為追蹤對象。"
   },
+  "shouldTrackDeletedWindowsLabel": {
+    "message": "Remove closed windows from saved sessions"
+  },
+  "shouldTrackDeletedWindowsCaptionLabel": {
+    "message": "When a window is closed within a tracking session, remove it from the tracked session."
+  },
   "ifAutoSaveLabel": {
     "message": "定期將開啟的分頁瀏覽階段自動儲存"
   },

--- a/src/background/open.js
+++ b/src/background/open.js
@@ -4,7 +4,7 @@ import log from "loglevel";
 import { getSettings } from "src/settings/settings";
 import { returnReplaceURL, replacePage } from "./replace.js";
 import { updateTabGroups } from "../common/tabGroups";
-import { isTrackingSession, startTracking } from "./track.js";
+import { isTrackingSession, startTracking, setFocusedId } from "./track.js";
 
 const logDir = "background/open";
 
@@ -13,6 +13,7 @@ export async function openSession(session, property = "openInNewWindow") {
   let isFirstWindowFlag = true;
   tabList = {};
   for (let win in session.windows) {
+    setFocusedId(browser.windows.WINDOW_ID_NONE);
     const openInCurrentWindow = async () => {
       log.log(logDir, "openSession() openInCurrentWindow()");
       const currentWindow = await removeNowOpenTabs();
@@ -24,7 +25,6 @@ export async function openSession(session, property = "openInNewWindow") {
 
       const firstTab = session.windows[win][Object.keys(session.windows[win])[0]];
       createData.incognito = firstTab.incognito;
-
 
       const isSetPosition =
         getSettings("isRestoreWindowPosition") && session.windowsInfo != undefined;

--- a/src/background/track.js
+++ b/src/background/track.js
@@ -9,6 +9,7 @@ const logDir = "background/track";
 export let IsTracking = false;
 
 let trackingWindows = [];
+let lastWindowId = browser.windows.WINDOW_ID_NONE;
 
 export const updateTrackingSession = async (tempSession) => {
   if (!IsTracking) return;
@@ -41,24 +42,70 @@ export const startTracking = (sessionId, originalWindowId, openedWindowId) => {
   // 同一のトラッキングセッションが複数開かれた際に、最後に開かれたもののみ追跡する
   trackingWindows = trackingWindows.filter(x => x.openedWindowId != originalWindowId && x.originalWindowId != originalWindowId);
   trackingWindows.push({ sessionId, originalWindowId, openedWindowId });
+  setFocusedId(openedWindowId);
 
   if (!IsTracking) {
+    browser.windows.onFocusChanged.addListener(setFocusedId);
     browser.windows.onRemoved.addListener(endTrackingByWindowClose);
     browser.windows.onCreated.addListener(handleCreateWindow);
     IsTracking = true;
   }
 
   updateTrackingStatus();
-  log.info(logDir, "startTracking()", trackingWindows);
+  log.info(logDir, "startTracking()", sessionId, originalWindowId, openedWindowId, trackingWindows);
 };
 
+export const setFocusedId = (windowId) => {
+  lastWindowId = windowId;
+  log.info(logDir, "setFocusedId()", windowId);
+}
+
 const handleCreateWindow = (window) => {
-  if (getSettings("shouldTrackNewWindow")) startTracking(trackingWindows[trackingWindows.length - 1].sessionId, window.id, window.id);
+  const trackedWindowId = lastWindowId;
+  if (!getSettings("shouldTrackNewWindow")) return;
+
+  // If the last window wasn't a valid window, skip
+  if (trackedWindowId < 0) return;
+
+  const focusedWindow = trackingWindows.find(x => x.openedWindowId === trackedWindowId || x.originalWindowId === trackedWindowId);
+  // If the last window that we were in isn't being tracked, don't track the new window
+  if (!focusedWindow) return;
+
+  startTracking(focusedWindow.sessionId, window.id, window.id);
 };
 
 export const endTrackingByWindowClose = (removedWindowId) => {
+  const { sessionId, originalWindowId, openedWindowId } = trackingWindows.find(x => x.openedWindowId == removedWindowId || x.originalWindowId == removedWindowId);
   trackingWindows = trackingWindows.filter(x => x.openedWindowId != removedWindowId);
   finalizeEndTracking();
+  deleteWindowFromSession(sessionId, originalWindowId, openedWindowId);
+};
+
+const deleteWindowFromSession = async (sessionId, originalWindowId, openedWindowId) => {
+  if (!getSettings("shouldTrackDeletedWindows")) return;
+
+  // If this was the last window for this session, we don't want to remove it
+  if (trackingWindows.filter(x => x.sessionId === sessionId).length === 0) return;
+
+  let trackedSession = await getSessions(sessionId);
+  if (!trackedSession) return;
+
+  log.info(logDir, "deleteWindowFromSession()", sessionId, originalWindowId, openedWindowId);
+
+  // Remove the window from the session
+  delete trackedSession.windows[originalWindowId];
+  delete trackedSession.windowsInfo[originalWindowId];
+  delete trackedSession.windows[openedWindowId];
+  delete trackedSession.windowsInfo[openedWindowId];
+
+  // Update windows / tabs number
+  trackedSession.windowsNumber = Object.keys(trackedSession.windows).length;
+  trackedSession.tabsNumber = 0;
+  for (const win of Object.values(trackedSession.windows)) {
+    trackedSession.tabsNumber += Object.keys(win).length;
+  }
+
+  await updateSession(trackedSession);
 };
 
 export const endTrackingBySessionId = sessionId => {
@@ -74,6 +121,7 @@ export const endTrackingByWindowDelete = (sessionId, windowId) => {
 const finalizeEndTracking = () => {
   if (!trackingWindows) {
     IsTracking = false;
+    browser.windows.onFocusChanged.removeListener(setFocusedId);
     browser.windows.onRemoved.removeListener(endTrackingByWindowClose);
     browser.windows.onCreated.removeListener(handleCreateWindow);
   }

--- a/src/settings/defaultSettings.js
+++ b/src/settings/defaultSettings.js
@@ -250,6 +250,13 @@ export default [
         captions: ["shouldTrackNewWindowCaptionLabel"],
         type: "checkbox",
         default: true,
+      },
+      {
+        id: "shouldTrackDeletedWindows",
+        title: "shouldTrackDeletedWindowsLabel",
+        captions: ["shouldTrackDeletedWindowsCaptionLabel"],
+        type: "checkbox",
+        default: false,
       }
     ]
   },


### PR DESCRIPTION
This fixes #1186 with the following changes:

- Better New Window Tracking
    - [x] FIX: Opening a saved session will no longer append itself to a tracking session
    - [x] FIX: New Windows are tracked to the currently focused session
- Closed Windows are now removed from tracking session
    - [x] ADDED: Closed Window Tracking Setting
        - When enabled, windows attached to a tracking session will be deleted from the session when they're closed 

This greatly improves the consistency of Session Tracking.