### PR TITLE
Fix alignment of close buttons so they aren't hidden by scrollbar

### DIFF
--- a/src/popup/styles/DetailsContainer.scss
+++ b/src/popup/styles/DetailsContainer.scss
@@ -41,6 +41,8 @@
       .buttonsContainer{
         display: none;
         flex-direction: row;
+        padding-right: 16px;
+        
         button {
           width: 15px;
           height: 15px;


### PR DESCRIPTION
This fixes #1204
<img width="144" alt="Screenshot 2023-10-22 at 7 21 36 pm" src="https://github.com/sienori/Tab-Session-Manager/assets/30827/ddc8808a-a1b6-432e-b637-3add58f94b04">

The above shows the new alignment, which is enough for the scrollbar not to obscure the close buttons.