### PR TITLE
use browser extension api for tab group management

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "react-transition-group": "^4.3.0",
         "url": "^0.11.0",
         "uuid": "^11.1.0",
-        "webextension-polyfill": "^0.7.0"
+        "webextension-polyfill": "^0.12.0"
       },
       "devDependencies": {
         "@babel/core": "^7.9.0",
@@ -10514,9 +10514,9 @@
       }
     },
     "node_modules/webextension-polyfill": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.7.0.tgz",
-      "integrity": "sha512-su48BkMLxqzTTvPSE1eWxKToPS2Tv5DLGxKexLEVpwFd6Po6N8hhSLIvG6acPAg7qERoEaDL+Y5HQJeJeml5Aw=="
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.12.0.tgz",
+      "integrity": "sha512-97TBmpoWJEE+3nFBQ4VocyCdLKfw54rFaJ6EVQYLBCXqCIpLSZkwGgASpv4oPt9gdKCJ80RJlcmNzNn008Ag6Q=="
     },
     "node_modules/webpack": {
       "version": "5.98.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "react-transition-group": "^4.3.0",
     "url": "^0.11.0",
     "uuid": "^11.1.0",
-    "webextension-polyfill": "^0.7.0"
+    "webextension-polyfill": "^0.12.0"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",

--- a/src/_locales/af/messages.json
+++ b/src/_locales/af/messages.json
@@ -492,7 +492,7 @@
     "message": "Save tab groups"
   },
   "saveTabGroupsCaptionLabel": {
-    "message": "Save and restore the state of tab groups. To enable this feature, you need to install the following extension."
+    "message": "Save and restore the state of tab groups."
   },
   "tstDelayCaptionLabel": {
     "message": "To restore the state of the tree, wait time is required to open the tab. Increase this value if the tree is not restored correctly."

--- a/src/_locales/ar/messages.json
+++ b/src/_locales/ar/messages.json
@@ -492,7 +492,7 @@
     "message": "Save tab groups"
   },
   "saveTabGroupsCaptionLabel": {
-    "message": "Save and restore the state of tab groups. To enable this feature, you need to install the following extension."
+    "message": "Save and restore the state of tab groups."
   },
   "tstDelayCaptionLabel": {
     "message": "لاستعادة وضع الشجرة، وقت الانتظار غلزامي لفتح التبويب، رفع هذه القيمة إذا كانت لم يتم استعادة الشجرة بنجاح."

--- a/src/_locales/ca/messages.json
+++ b/src/_locales/ca/messages.json
@@ -492,7 +492,7 @@
     "message": "Save tab groups"
   },
   "saveTabGroupsCaptionLabel": {
-    "message": "Save and restore the state of tab groups. To enable this feature, you need to install the following extension."
+    "message": "Save and restore the state of tab groups."
   },
   "tstDelayCaptionLabel": {
     "message": "To restore the state of the tree, wait time is required to open the tab. Increase this value if the tree is not restored correctly."

--- a/src/_locales/cs/messages.json
+++ b/src/_locales/cs/messages.json
@@ -492,7 +492,7 @@
     "message": "Save tab groups"
   },
   "saveTabGroupsCaptionLabel": {
-    "message": "Save and restore the state of tab groups. To enable this feature, you need to install the following extension."
+    "message": "Save and restore the state of tab groups."
   },
   "tstDelayCaptionLabel": {
     "message": "To restore the state of the tree, wait time is required to open the tab. Increase this value if the tree is not restored correctly."

--- a/src/_locales/da/messages.json
+++ b/src/_locales/da/messages.json
@@ -492,7 +492,7 @@
     "message": "Save tab groups"
   },
   "saveTabGroupsCaptionLabel": {
-    "message": "Save and restore the state of tab groups. To enable this feature, you need to install the following extension."
+    "message": "Save and restore the state of tab groups."
   },
   "tstDelayCaptionLabel": {
     "message": "To restore the state of the tree, wait time is required to open the tab. Increase this value if the tree is not restored correctly."

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -492,7 +492,7 @@
     "message": "Tab-Gruppen speichern"
   },
   "saveTabGroupsCaptionLabel": {
-    "message": "Speichern und Wiederherstellen des Zustands von Tab-Gruppen. Um diese Funktion zu aktivieren, müssen Sie die folgende Erweiterung installieren."
+    "message": "Speichern und Wiederherstellen des Zustands von Tab-Gruppen."
   },
   "tstDelayCaptionLabel": {
     "message": "Um den Zustand der Baumstruktur wiederherzustellen, ist eine gewisse Verzögerung notwendig. Falls die Baumstruktur nicht korrekt wiederhergestellt wird, kann der Wert erhöht werden."

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -492,7 +492,7 @@
     "message": "Save tab groups"
   },
   "saveTabGroupsCaptionLabel": {
-    "message": "Save and restore the state of tab groups. To enable this feature, you need to install the following extension."
+    "message": "Save and restore the state of tab groups."
   },
   "tstDelayCaptionLabel": {
     "message": "To restore the state of the tree, wait time is required to open the tab. Increase this value if the tree is not restored correctly."

--- a/src/_locales/he/messages.json
+++ b/src/_locales/he/messages.json
@@ -492,7 +492,7 @@
     "message": "Save tab groups"
   },
   "saveTabGroupsCaptionLabel": {
-    "message": "Save and restore the state of tab groups. To enable this feature, you need to install the following extension."
+    "message": "Save and restore the state of tab groups."
   },
   "tstDelayCaptionLabel": {
     "message": "כדי לשחזר את מצב העץ, נדרש זמן המתנה לפתיחת הכרטיסיה. הגדל ערך זה אם העץ אינו משוחזר כהלכה."

--- a/src/_locales/hi/messages.json
+++ b/src/_locales/hi/messages.json
@@ -492,7 +492,7 @@
     "message": "Save tab groups"
   },
   "saveTabGroupsCaptionLabel": {
-    "message": "Save and restore the state of tab groups. To enable this feature, you need to install the following extension."
+    "message": "Save and restore the state of tab groups."
   },
   "tstDelayCaptionLabel": {
     "message": "To restore the state of the tree, wait time is required to open the tab. Increase this value if the tree is not restored correctly."

--- a/src/_locales/id/messages.json
+++ b/src/_locales/id/messages.json
@@ -492,7 +492,7 @@
     "message": "Save tab groups"
   },
   "saveTabGroupsCaptionLabel": {
-    "message": "Save and restore the state of tab groups. To enable this feature, you need to install the following extension."
+    "message": "Save and restore the state of tab groups."
   },
   "tstDelayCaptionLabel": {
     "message": "To restore the state of the tree, wait time is required to open the tab. Increase this value if the tree is not restored correctly."

--- a/src/_locales/nl/messages.json
+++ b/src/_locales/nl/messages.json
@@ -492,7 +492,7 @@
     "message": "Save tab groups"
   },
   "saveTabGroupsCaptionLabel": {
-    "message": "Save and restore the state of tab groups. To enable this feature, you need to install the following extension."
+    "message": "Save and restore the state of tab groups."
   },
   "tstDelayCaptionLabel": {
     "message": "Om de staat van een boomstructuur te herstellen, is een wachttijd vereist voor het openen van de tab. Verhoog deze waarde indien de boomstructuur niet correct wordt teruggezet."

--- a/src/_locales/no/messages.json
+++ b/src/_locales/no/messages.json
@@ -492,7 +492,7 @@
     "message": "Lagra fanegrupper"
   },
   "saveTabGroupsCaptionLabel": {
-    "message": "Lagra og gjenopprett plasseringa til fanegrupper. For å slå på denne funksjonen treng du den følgjande utvidinga."
+    "message": "Lagra og gjenopprett plasseringa til fanegrupper."
   },
   "tstDelayCaptionLabel": {
     "message": "For å gjenoppretta trestrukturen må du venta litt før du kan opna fana. Øk denne verdien viss treet ikkje vert gjenoppretta riktig."

--- a/src/_locales/ro/messages.json
+++ b/src/_locales/ro/messages.json
@@ -492,7 +492,7 @@
     "message": "Save tab groups"
   },
   "saveTabGroupsCaptionLabel": {
-    "message": "Save and restore the state of tab groups. To enable this feature, you need to install the following extension."
+    "message": "Save and restore the state of tab groups."
   },
   "tstDelayCaptionLabel": {
     "message": "To restore the state of the tree, wait time is required to open the tab. Increase this value if the tree is not restored correctly."

--- a/src/_locales/sr/messages.json
+++ b/src/_locales/sr/messages.json
@@ -492,7 +492,7 @@
     "message": "Save tab groups"
   },
   "saveTabGroupsCaptionLabel": {
-    "message": "Save and restore the state of tab groups. To enable this feature, you need to install the following extension."
+    "message": "Save and restore the state of tab groups."
   },
   "tstDelayCaptionLabel": {
     "message": "To restore the state of the tree, wait time is required to open the tab. Increase this value if the tree is not restored correctly."

--- a/src/_locales/sv/messages.json
+++ b/src/_locales/sv/messages.json
@@ -492,7 +492,7 @@
     "message": "Spara flikgrupper"
   },
   "saveTabGroupsCaptionLabel": {
-    "message": "Spara och återställ läget för flikgrupper. För att aktivera den här funktionen måste du installera följande tillägg."
+    "message": "Spara och återställ läget för flikgrupper."
   },
   "tstDelayCaptionLabel": {
     "message": "För att återställa trädet krävs det väntetid innan fliken öppnas. Höj värdet om trädet inte återställs korrekt."

--- a/src/_locales/vi/messages.json
+++ b/src/_locales/vi/messages.json
@@ -492,7 +492,7 @@
     "message": "Save tab groups"
   },
   "saveTabGroupsCaptionLabel": {
-    "message": "Save and restore the state of tab groups. To enable this feature, you need to install the following extension."
+    "message": "Save and restore the state of tab groups."
   },
   "tstDelayCaptionLabel": {
     "message": "Để phục hồi trạng thái của cây, cần có thời gian chờ để mở tab. Tăng thời gian chờ nếu cây không được khôi phục một cách chính xác."

--- a/src/background/open.js
+++ b/src/background/open.js
@@ -102,7 +102,9 @@ const isEnabledOpenerTabId =
   (browserInfo().name == "Chrome" && browserInfo().version >= 18);
 const isEnabledDiscarded = browserInfo().name == "Firefox" && browserInfo().version >= 63;
 const isEnabledOpenInReaderMode = browserInfo().name == "Firefox" && browserInfo().version >= 58;
-const isEnabledTabGroups = browserInfo().name == "Chrome" && browserInfo().version >= 89;
+const isEnabledTabGroups =
+  (browserInfo().name == "Chrome" && browserInfo().version >= 89) ||
+  (browserInfo().name == "Firefox" && browserInfo().version >= 137);
 const isEnabledWindowTitle = browserInfo().name == "Firefox";
 
 //ウィンドウとタブを閉じてcurrentWindowを返す

--- a/src/background/save.js
+++ b/src/background/save.js
@@ -13,7 +13,9 @@ import { compressDataUrl } from "../common/compressDataUrl";
 
 const logDir = "background/save";
 
-const isEnabledTabGroups = browserInfo().name == "Chrome" && browserInfo().version >= 89;
+const isEnabledTabGroups =
+  (browserInfo().name == "Chrome" && browserInfo().version >= 89) ||
+  (browserInfo().name == "Firefox" && browserInfo().version >= 137);
 
 export async function saveCurrentSession(name, tag, property) {
   log.log(logDir, "saveCurrentSession()", name, tag, property);

--- a/src/common/tabGroups.js
+++ b/src/common/tabGroups.js
@@ -3,9 +3,10 @@ import log from "loglevel";
 
 const logDir = "common/tabGroups";
 
-const saveTabGroupsExtensionId = "aghdiknflpelpkepifoplhodcnfildao";
+// const saveTabGroupsExtensionId = "aghdiknflpelpkepifoplhodcnfildao";
 
 export const queryTabGroups = async (queryInfo = {}) => {
+  /*
   const message = {
     request: "query",
     queryInfo
@@ -16,12 +17,15 @@ export const queryTabGroups = async (queryInfo = {}) => {
       log.error(logDir, "getTabGroups", e);
       return [];
     });
+  */
+  const tabGroups = await browser.tabs.query(queryInfo);
   log.log(logDir, "getTabGroups", tabGroups);
   return tabGroups;
 };
 
 export const updateTabGroups = async (groupId, updateProperties) => {
   log.log(logDir, "updateTabGroups");
+  /*
   const { title, color, collapsed } = updateProperties;
   const message = {
     request: "update",
@@ -31,4 +35,8 @@ export const updateTabGroups = async (groupId, updateProperties) => {
     }
   };
   browser.runtime.sendMessage(saveTabGroupsExtensionId, message);
+
+   */
+
+  await browser.tabs.update(groupId, updateProperties)
 };

--- a/src/manifest-ff.json
+++ b/src/manifest-ff.json
@@ -16,7 +16,8 @@
     "cookies",
     "downloads",
     "identity",
-    "alarms"
+    "alarms",
+    "tabGroups"
   ],
   "optional_permissions": [
     "https://www.googleapis.com/*"

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -11,7 +11,8 @@
     "downloads",
     "identity",
     "alarms",
-    "offscreen"
+    "offscreen",
+    "tabGroups"
   ],
   "optional_host_permissions": [
     "https://www.googleapis.com/*"

--- a/src/settings/defaultSettings.js
+++ b/src/settings/defaultSettings.js
@@ -63,13 +63,9 @@ export default [
         id: "saveTabGroups",
         title: "saveTabGroupsLabel",
         captions: ["saveTabGroupsCaptionLabel"],
-        link: {
-          href: "https://chrome.google.com/webstore/detail/aghdiknflpelpkepifoplhodcnfildao/",
-          text: "Save Tab Groups for Tab Session Manager"
-        },
         type: "checkbox",
         default: false,
-        shouldShow: browserInfo().name == "Chrome" && browserInfo().version >= 89,
+        shouldShow: (browserInfo().name == "Chrome" && browserInfo().version >= 89) || (browserInfo().name == "Firefox" && browserInfo().version >= 137),
       },
       {
         id: "ifSavePrivateWindow",


### PR DESCRIPTION
This should fix #1480 and also make the need for a chrome extension for tab groups obsolete.

I wasn't sure how to handle the locales, so most languages will probably still claim you need that separate chrome extension for tab groups; I only fixed the text for languages I know decently well.