### PR TITLE
[bugfix] Fix removed tag actions not being logged in the undo/redo log

### DIFF
--- a/src/background/background.js
+++ b/src/background/background.js
@@ -124,7 +124,7 @@ const onMessageListener = async (request, sender, sendResponse) => {
     }
     case "removeTag": {
       const beforeSession = await getSessions(request.id);
-      const afterSession = removeTag(request.id, request.tag);
+      const afterSession = await removeTag(request.id, request.tag);
       recordChange(beforeSession, afterSession);
       break;
     }


### PR DESCRIPTION
When a tag was removed this action was not logged in the undo/redo log and as such undo-ing a remove-tag action was impossible. 

The reason for this bug was a missing `await`.

This change fixes this by adding the missing `await` which causes the undo action to be added to the undo/redo log.