### PR TITLE
Add sorting by last updated time to sessions

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -53,6 +53,14 @@
   "oldestLabel": {
     "message": "Oldest"
   },
+
+"modifiedNewestLabel": {
+  "message": "Last updated (newest)"
+},
+"modifiedOldestLabel": {
+  "message": "Last updated (oldest)"
+},
+
   "aToZLabel": {
     "message": "A-Z"
   },

--- a/src/_locales/hu/messages.json
+++ b/src/_locales/hu/messages.json
@@ -11,6 +11,17 @@
   "donateLabel": {
     "message": "Adományozz"
   },
+
+
+"modifiedNewestLabel": {
+  "message": "Legutóbb frissítve"
+},
+"modifiedOldestLabel": {
+  "message": "Legrégebb frissítve"
+},
+
+
+
   "openSessionListInTabLabel": {
     "message": "Munkamenet lista megnyitása a fülön"
   },

--- a/src/popup/components/OptionsArea.js
+++ b/src/popup/components/OptionsArea.js
@@ -152,7 +152,11 @@ export default class OptionsArea extends Component {
               value={this.props.sortValue}
               title={browser.i18n.getMessage("sortLabel")}
             >
-              <option value="newest">{browser.i18n.getMessage("newestLabel")}</option>
+              
+		<option value="modifiedNewest">{browser.i18n.getMessage("modifiedNewestLabel")}</option>
+		<option value="modifiedOldest">{browser.i18n.getMessage("modifiedOldestLabel")}</option>
+
+		<option value="newest">{browser.i18n.getMessage("newestLabel")}</option>
               <option value="oldest">{browser.i18n.getMessage("oldestLabel")}</option>
               <option value="aToZ">{browser.i18n.getMessage("aToZLabel")}</option>
               <option value="zToA">{browser.i18n.getMessage("zToALabel")}</option>

--- a/src/popup/components/SessionsArea.js
+++ b/src/popup/components/SessionsArea.js
@@ -28,6 +28,7 @@ const matchesSearch = (searchWords, sessionId, searchedSessionIds) => {
 };
 
 const newestSort = (a, b) => b.date - a.date;
+const modifiedNewestSort = (a, b) => b.modified - a.modified;
 const alphabeticallySort = (a, b) => {
   if (a.name.toLowerCase() > b.name.toLowerCase()) return 1;
   else if (a.name.toLowerCase() < b.name.toLowerCase()) return -1;
@@ -48,12 +49,15 @@ export const getSortedSessions = (
   searchedSessionIds
 ) => {
   let sortedSessions = sessions.map(session => ({
-    id: session.id,
-    date: session.date,
-    name: session.name,
-    tag: session.tag,
-    tabsNumber: session.tabsNumber
-  }));
+  id: session.id,
+  date: session.date,
+  modified: session.lastEditedTime ?? session.modified ?? session.date,
+ // fallback, ha régi mentésben nincs modified
+  name: session.name,
+  tag: session.tag,
+  tabsNumber: session.tabsNumber
+}));
+
   sortedSessions = sortedSessions.filter(
     session =>
       matchesFilter(session.tag, filterValue) &&
@@ -61,6 +65,13 @@ export const getSortedSessions = (
   );
 
   switch (sortValue) {
+case "modifiedNewest":
+    sortedSessions.sort(modifiedNewestSort);
+    break;
+  case "modifiedOldest":
+    sortedSessions.sort(modifiedNewestSort);
+    sortedSessions.reverse();
+    break;
     case "newest":
       sortedSessions.sort(newestSort);
       break;


### PR DESCRIPTION
This PR adds two new sort options to the session list:
- Last updated (newest)
- Last updated (oldest)

It uses the existing lastEditedTime field with a fallback to the creation date,
so it remains backward compatible with older sessions.
