### PR TITLE
add min tabs count for win close autosave

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -365,6 +365,12 @@
   "autoSaveWhenCloseCaptionLabel": {
     "message": "Maximum number of saved sessions (in this way)."
   },
+  "autoSaveWhenCloseMinTabsLabel": {
+    "message": "Minimum number of tabs"
+  },
+  "autoSaveWhenCloseMinTabsCaptionLabel": {
+    "message": "If the number of tabs is fewer, the window is not saved."
+  },
   "ifAutoSaveWhenExitBrowserLabel": {
     "message": "Save the session when exiting browser"
   },

--- a/src/background/autoSave.js
+++ b/src/background/autoSave.js
@@ -124,6 +124,11 @@ export const autoSaveWhenWindowClose = async removedWindowId => {
   }
   const removedWindow = session.windows[removedWindowId];
   if (removedWindow == undefined) return;
+
+  const tabsNumber = Object.keys(removedWindow).length;
+  const minTabs = getSettings("autoSaveWhenCloseMinTabs")
+  if (tabsNumber < minTabs) return;
+
   if (getSettings("useTabTitleforAutoSave")) {
     const activeTab = Object.values(removedWindow).find(tab => tab.active);
     session.name = activeTab.title;
@@ -134,7 +139,7 @@ export const autoSaveWhenWindowClose = async removedWindowId => {
   session.tag = ["winClose"];
   session.id = uuidv4();
   session.windowsNumber = 1;
-  session.tabsNumber = Object.keys(removedWindow).length;
+  session.tabsNumber = tabsNumber;
 
   await saveSession(session);
 

--- a/src/settings/defaultSettings.js
+++ b/src/settings/defaultSettings.js
@@ -171,6 +171,15 @@ export default [
             min: 1,
             placeholder: 10,
             default: 10
+          },
+          {
+            id: "autoSaveWhenCloseMinTabs",
+            title: "autoSaveWhenCloseMinTabsLabel",
+            captions: ["autoSaveWhenCloseMinTabsCaptionLabel"],
+            type: "number",
+            min: 1,
+            placeholder: 1,
+            default: 1
           }
         ]
       },


### PR DESCRIPTION
Add option to prevent saving windows on close if number of tabs is less than a given number.
Closes https://github.com/sienori/Tab-Session-Manager/issues/1305

<img width="968" height="96" alt="image" src="https://github.com/user-attachments/assets/b1460c42-c051-4429-bdcd-85349b748f95" />
