### PR TITLE
double max popup window size

### DIFF
--- a/src/settings/defaultSettings.js
+++ b/src/settings/defaultSettings.js
@@ -410,7 +410,7 @@ export default [
             captions: [""],
             type: "number",
             min: 300,
-            max: 800,
+            max: 1600,
             placeholder: 700,
             default: 700
           },
@@ -420,7 +420,7 @@ export default [
             captions: [""],
             type: "number",
             min: 200,
-            max: 600,
+            max: 1200,
             placeholder: 500,
             default: 500
           },


### PR DESCRIPTION
With high resolutions the default 800x600 looks a bit small, so I doubled it. Maybe 1600x1200 is not ideal, but it definitely needs to be enlarged IMO.

This changes only max values, not default/current.