### PR TITLE
Add limited auto track option

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -335,6 +335,12 @@
   "shouldTrackNewWindowCaptionLabel": {
     "message": "When a new window is opened within a tracking session, include it in the tracking."
   },
+  "autoTrackCurrentWindowSessionLabel": {
+    "message": "Automatically track when current window saved"
+  },
+  "autoTrackCurrentWindowSessionCaptionLabel": {
+    "message": "When a new session saved with only the current window, and it is not tracked yet, automatically enable tracking."
+  },
   "ifAutoSaveLabel": {
     "message": "Save the session regularly"
   },

--- a/src/background/autoSave.js
+++ b/src/background/autoSave.js
@@ -3,7 +3,8 @@ import { v4 as uuidv4 } from "uuid";
 import log from "loglevel";
 import { openSession } from "./open.js";
 import { getSessionsByTag } from "./tag.js";
-import { loadCurrentSession, saveSession, removeSession } from "./save.js";
+import removeSession from "./removeSession";
+import { loadCurrentSession, saveSession } from "./save.js";
 import { getSettings } from "src/settings/settings";
 import { getTrackingInfo, updateTrackingSession } from "./track.js";
 import { init } from "./background.js";
@@ -126,7 +127,7 @@ export const autoSaveWhenWindowClose = async removedWindowId => {
   if (removedWindow == undefined) return;
 
   const tabsNumber = Object.keys(removedWindow).length;
-  const minTabs = getSettings("autoSaveWhenCloseMinTabs")
+  const minTabs = getSettings("autoSaveWhenCloseMinTabs");
   if (tabsNumber < minTabs) return;
 
   if (getSettings("useTabTitleforAutoSave")) {

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -15,11 +15,11 @@ import Sessions from "./sessions";
 import { replacePage } from "./replace";
 import importSessions from "./import";
 import { backupSessions, resetLastBackupTime } from "./backup";
+import removeSession from "./removeSession";
 import {
   loadCurrentSession,
   saveCurrentSession,
   saveSession,
-  removeSession,
   deleteAllSessions,
   updateSession,
   renameSession,
@@ -40,7 +40,12 @@ import { updateLogLevel, overWriteLogLevel } from "../common/log";
 import { getsearchInfo } from "./search";
 import { recordChange, undo, redo, updateUndoStatus } from "./undo";
 import { compressAllSessions } from "./compressAllSessions";
-import { startTracking, endTrackingByWindowDelete, updateTrackingStatus } from "./track";
+import {
+  startTracking,
+  endAllTracking,
+  endTrackingByWindowDelete,
+  updateTrackingStatus
+} from "./track";
 
 const logDir = "background/background";
 
@@ -111,7 +116,8 @@ const onMessageListener = async (request, sender, sendResponse) => {
       exportSessions(request.id);
       break;
     case "deleteAllSessions":
-      deleteAllSessions();
+      await deleteAllSessions();
+      await endAllTracking();
       break;
     case "getSessions":
       const sessions = await getSessions(request.id, request.needKeys);

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -18,7 +18,6 @@ import { backupSessions, resetLastBackupTime } from "./backup";
 import removeSession from "./removeSession";
 import {
   loadCurrentSession,
-  saveCurrentSession,
   saveSession,
   deleteAllSessions,
   updateSession,
@@ -28,6 +27,7 @@ import {
 import getSessions from "./getSessions";
 import { openSession } from "./open";
 import { addTag, removeTag, applyDeviceName } from "./tag";
+import saveCurrentSessionWithTracking from "./saveCurrentSessionWithTracking";
 import { initSettings, handleSettingsChange, getSettings } from "src/settings/settings";
 import exportSessions, { handleDownloadsChanged } from "./export";
 import onInstalledListener from "./onInstalledListener";
@@ -85,7 +85,7 @@ const onMessageListener = async (request, sender, sendResponse) => {
     case "saveCurrentSession":
       const name = request.name;
       const property = request.property;
-      const afterSession = await saveCurrentSession(name, [], property);
+      const afterSession = await saveCurrentSessionWithTracking(name, [], property);
       recordChange(null, afterSession);
       return afterSession;
     case "open":

--- a/src/background/keyboardShortcuts.js
+++ b/src/background/keyboardShortcuts.js
@@ -2,7 +2,7 @@ import browser from "webextension-polyfill";
 import browserInfo from "browser-info";
 import log from "loglevel";
 import { getSettings, setSettings } from "src/settings/settings";
-import { saveCurrentSession } from "./save";
+import saveCurrentSessionWithTracking from "./saveCurrentSessionWithTracking";
 import exportSessions from "./export";
 import getShortcut from "src/common/getShortcut";
 import { showDoneBadge } from "./setBadge";
@@ -52,13 +52,13 @@ export const onCommandListener = async command => {
   switch (command) {
     case "saveAllWindow": {
       const name = await getCurrentTabName();
-      saveCurrentSession(name, [], "saveAllWindows");
+      saveCurrentSessionWithTracking(name, [], "saveAllWindows");
       showDoneBadge();
       break;
     }
     case "saveCurrentWindow": {
       const name = await getCurrentTabName();
-      saveCurrentSession(name, [], "saveOnlyCurrentWindow");
+      saveCurrentSessionWithTracking(name, [], "saveOnlyCurrentWindow");
       showDoneBadge();
       break;
     }

--- a/src/background/removeSession.js
+++ b/src/background/removeSession.js
@@ -1,0 +1,22 @@
+import browser from "webextension-polyfill";
+import log from "loglevel";
+import Sessions from "./sessions.js";
+import { pushRemovedQueue } from "./cloudSync.js";
+import { endTrackingBySessionId } from "./track.js";
+
+const logDir = "background/removeSession";
+
+export default async function removeSession(id, isSendResponse = true) {
+  log.log(logDir, "removeSession()", id, isSendResponse);
+  endTrackingBySessionId(id).catch(() => {});
+  try {
+    await Sessions.delete(id);
+    pushRemovedQueue(id);
+    if (isSendResponse) {
+      browser.runtime.sendMessage({ message: "deleteSession", id: id }).catch(() => {});
+    }
+  } catch (e) {
+    log.error(logDir, "removeSession()", e);
+    return Promise.reject(e);
+  }
+}

--- a/src/background/save.js
+++ b/src/background/save.js
@@ -6,7 +6,7 @@ import Sessions from "./sessions.js";
 import { getSettings } from "src/settings/settings";
 import { returnReplaceParameter } from "./replace.js";
 import ignoreUrls from "./ignoreUrls";
-import { pushRemovedQueue, syncCloudAuto } from "./cloudSync.js";
+import { syncCloudAuto } from "./cloudSync.js";
 import { getValidatedTag } from "./tag.js";
 import { queryTabGroups, isEnabledTabGroups } from "../common/tabGroups";
 import { compressDataUrl } from "../common/compressDataUrl";
@@ -130,18 +130,6 @@ export async function saveSession(session, isSendResponce = true, saveBySync = f
     return session;
   } catch (e) {
     log.error(logDir, "saveSession()", e);
-    return Promise.reject(e);
-  }
-}
-
-export async function removeSession(id, isSendResponce = true) {
-  log.log(logDir, "removeSession()", id, isSendResponce);
-  try {
-    await Sessions.delete(id);
-    pushRemovedQueue(id);
-    if (isSendResponce) sendMessage("deleteSession", { id: id });
-  } catch (e) {
-    log.error(logDir, "removeSession()", e);
     return Promise.reject(e);
   }
 }

--- a/src/background/saveCurrentSessionWithTracking.js
+++ b/src/background/saveCurrentSessionWithTracking.js
@@ -1,0 +1,40 @@
+import log from "loglevel";
+import { getSettings } from "src/settings/settings";
+import { saveCurrentSession, updateSession } from "./save";
+import { getTrackingInfo, startTracking } from "./track";
+
+const logDir = "background/saveCurrentSessionWithTracking";
+
+const isTrackedWindow = (trackingWindows, windowId) => {
+  return trackingWindows.some(
+    ({ originalWindowId, openedWindowId }) =>
+      originalWindowId == windowId || openedWindowId == windowId
+  );
+};
+
+export default async function saveCurrentSessionWithTracking(name, tag, property) {
+  const session = await saveCurrentSession(name, tag, property);
+
+  if (property !== "saveOnlyCurrentWindow") return session;
+  if (!getSettings("autoTrackCurrentWindowSession")) return session;
+
+  const currentWindowId = parseInt(Object.keys(session.windows)[0]);
+  if (Number.isNaN(currentWindowId)) return session;
+
+  const { trackingWindows } = await getTrackingInfo();
+  if (isTrackedWindow(trackingWindows, currentWindowId)) {
+    log.log(logDir, "saveCurrentSessionWithTracking() tracking skipped", {
+      sessionId: session.id,
+      currentWindowId
+    });
+    return session;
+  }
+
+  if (!session.tag.includes("_tracking")) {
+    session.tag.push("_tracking");
+    await updateSession(session);
+  }
+
+  await startTracking(session.id, currentWindowId, currentWindowId);
+  return session;
+}

--- a/src/background/track.js
+++ b/src/background/track.js
@@ -158,6 +158,12 @@ export const endTrackingBySessionId = async sessionId => {
   await finalizeEndTracking();
 };
 
+export const endAllTracking = async () => {
+  let { isTracking } = await getTrackingInfo();
+  await setTrackingInfo([], isTracking);
+  await finalizeEndTracking();
+};
+
 export const endTrackingByWindowDelete = async (sessionId, windowId) => {
   let { trackingWindows, isTracking } = await getTrackingInfo();
   trackingWindows = trackingWindows.filter(

--- a/src/background/undo.js
+++ b/src/background/undo.js
@@ -1,6 +1,7 @@
 import browser from "webextension-polyfill";
 import log from "loglevel";
-import { updateSession, removeSession } from "./save";
+import removeSession from "./removeSession";
+import { updateSession } from "./save";
 
 const logDir = "background/undo";
 

--- a/src/settings/defaultSettings.js
+++ b/src/settings/defaultSettings.js
@@ -254,6 +254,13 @@ export default [
         captions: ["shouldTrackNewWindowCaptionLabel"],
         type: "checkbox",
         default: true
+      },
+      {
+        id: "autoTrackCurrentWindowSession",
+        title: "autoTrackCurrentWindowSessionLabel",
+        captions: ["autoTrackCurrentWindowSessionCaptionLabel"],
+        type: "checkbox",
+        default: false
       }
     ]
   },


### PR DESCRIPTION
## Summary

Introduce an optional setting to automatically enable tracking when saving a session for the **current window only**, under controlled conditions. The implementation is **backward-compatible**, and the new configuration option is **disabled by default**.

Related: #1532 (refined to apply only to current-window saves with strict scoping)

## Motivation

In my workflow, when I save the current window, I want to start tracking it immediately.

Today, that requires the following steps:

1. Save the current window as a new session
2. Enable tracking for that session
3. Open the created session in a new window
4. Close the original window

These steps add unnecessary friction to a workflow that is otherwise naturally window-scoped.

This feature is intended to streamline that workflow while preserving the existing session-based design and avoiding ambiguity.

## Proposed Behavior

Add a new setting:

* [ ] **Automatically track saved current window sessions**

When enabled:

* if the user saves a session using **"Save only current window"**
* and there is **no active tracking session already associated with that window** (to avoid conflicts)

then the newly created session is automatically marked as a **tracking session** and begins tracking the existing current window immediately.

## Explicit Non-Goals

To avoid ambiguity and unintended side effects, this feature:

* does **not** apply when saving **all windows**
* does **not** override or replace an existing tracking session for the same window
* does **not** affect other windows implicitly
* does **not** enable global or multi-window tracking

## Expected Benefits

* Reduces friction for users working in **window-scoped workflows**
* Improves ergonomics for users who regularly save and track the current window
* Preserves the current explicit tracking model while offering an optional convenience feature

## Design Considerations

* Tracking remains **opt-in** through a dedicated setting
* Behavior is **strictly scoped** to reduce ambiguity
* Existing session and tracking semantics remain unchanged
* Default behavior is unchanged
