### PR TITLE
Improve TST restoration accuracy and speed

### DIFF
--- a/src/background/open.js
+++ b/src/background/open.js
@@ -189,33 +189,42 @@ async function createTabs(session, win, currentWindow, isAddtoCurrentWindow = fa
     sortedTabs.forEach(tab => tab.index++);
   }
   let openedTabs = [];
-  let tabNumber = 0;
   for (let tab of sortedTabs) {
     const openedTab = openTab(tab, currentWindow, isAddtoCurrentWindow)
-      .then(() => {
-        tabNumber++;
-        if (tabNumber == 1 && !isAddtoCurrentWindow) browser.tabs.remove(firstTabId);
-        if (tabNumber == sortedTabs.length) replacePage(currentWindow.id);
-      })
       .catch(() => {});
     openedTabs.push(openedTab);
-    if (getSettings("ifSupportTst")) await openedTab;
+  }
+  await Promise.all(openedTabs);
+  if (!isAddtoCurrentWindow) browser.tabs.remove(firstTabId);
+  replacePage(currentWindow.id);
+
+  if (getSettings("ifSupportTst") && isEnabledOpenerTabId) {
+    await restoreTabHierarchy(sortedTabs);
   }
 
   if (isEnabledTabGroups) {
-    await Promise.all(openedTabs);
     createTabGroups(currentWindow.id, sortedTabs, session.tabGroups || []);
   }
 
   if (isEnabledWindowTitle) {
-    await Promise.all(openedTabs);
     setWindowTitle(session, win, currentWindow);
   }
 
   if (isTrackingSession(session.tag)) {
-    await Promise.all(openedTabs);
     startTracking(session.id, win, currentWindow.id);
   }
+}
+
+async function restoreTabHierarchy(tabs) {
+  const validTabOrdering = tabs.filter(tab => tabList?.[tab.id] !== undefined);
+
+  //ensure tabs are not jumbled before restoring hierarchy
+  const validTabIds = validTabOrdering.map(tab => tabList[tab.id]);
+  await browser.tabs.move(validTabIds, { index: 0 });
+
+  const tasks = validTabOrdering
+    .map(tab => browser.tabs.update(tabList[tab.id], { openerTabId: tabList[tab.openerTabId] ?? -1 }));
+  await Promise.all(tasks);
 }
 
 let tabList = {};
@@ -249,7 +258,6 @@ function openTab(tab, currentWindow, isOpenToLastIndex = false) {
     //Tree Style Tab
     let openDelay = 0;
     if (getSettings("ifSupportTst") && isEnabledOpenerTabId) {
-      createOption.openerTabId = tabList[tab.openerTabId];
       openDelay = getSettings("tstDelay");
     }
 

--- a/src/background/open.js
+++ b/src/background/open.js
@@ -184,6 +184,11 @@ async function createTabs(session, win, currentWindow, isAddtoCurrentWindow = fa
     return a.index - b.index;
   });
 
+  let openDelay = -1;
+  if (getSettings("ifSupportTst") && isEnabledOpenerTabId) {
+    openDelay = getSettings("tstDelay");
+  }
+
   const firstTabId = currentWindow.tabs[0].id;
   if (currentWindow.tabs[0].pinned) {
     sortedTabs.forEach(tab => tab.index++);
@@ -193,6 +198,7 @@ async function createTabs(session, win, currentWindow, isAddtoCurrentWindow = fa
     const openedTab = openTab(tab, currentWindow, isAddtoCurrentWindow)
       .catch(() => {});
     openedTabs.push(openedTab);
+    if (openDelay >= 0) await openedTab;
   }
   await Promise.all(openedTabs);
   if (!isAddtoCurrentWindow) browser.tabs.remove(firstTabId);
@@ -216,6 +222,8 @@ async function createTabs(session, win, currentWindow, isAddtoCurrentWindow = fa
 }
 
 async function restoreTabHierarchy(tabs) {
+  log.log(logDir, "restoreTabHierarchy()", tabs);
+
   const validTabOrdering = tabs.filter(tab => tabList?.[tab.id] !== undefined);
 
   //ensure tabs are not jumbled before restoring hierarchy

--- a/src/background/open.js
+++ b/src/background/open.js
@@ -193,6 +193,8 @@ async function createTabs(session, win, currentWindow, isAddtoCurrentWindow = fa
   if (currentWindow.tabs[0].pinned) {
     sortedTabs.forEach(tab => tab.index++);
   }
+
+  const existingTabCount = currentWindow.tabs.length;
   let openedTabs = [];
   for (let tab of sortedTabs) {
     const openedTab = openTab(tab, currentWindow, isAddtoCurrentWindow)
@@ -200,12 +202,14 @@ async function createTabs(session, win, currentWindow, isAddtoCurrentWindow = fa
     openedTabs.push(openedTab);
     if (openDelay >= 0) await openedTab;
   }
+
   await Promise.all(openedTabs);
   if (!isAddtoCurrentWindow) browser.tabs.remove(firstTabId);
   replacePage(currentWindow.id);
 
   if (getSettings("ifSupportTst") && isEnabledOpenerTabId) {
-    await restoreTabHierarchy(sortedTabs);
+    const offset = isAddtoCurrentWindow ? existingTabCount : 0;
+    await restoreTabHierarchy(sortedTabs, offset);
   }
 
   if (isEnabledTabGroups) {
@@ -221,14 +225,14 @@ async function createTabs(session, win, currentWindow, isAddtoCurrentWindow = fa
   }
 }
 
-async function restoreTabHierarchy(tabs) {
-  log.log(logDir, "restoreTabHierarchy()", tabs);
+async function restoreTabHierarchy(tabs, offset = 0) {
+  log.log(logDir, "restoreTabHierarchy()", tabs, offset);
 
   const validTabOrdering = tabs.filter(tab => tabList?.[tab.id] !== undefined);
 
   //ensure tabs are not jumbled before restoring hierarchy
   const validTabIds = validTabOrdering.map(tab => tabList[tab.id]);
-  await browser.tabs.move(validTabIds, { index: 0 });
+  await browser.tabs.move(validTabIds, { index: offset });
 
   const tasks = validTabOrdering
     .map(tab => browser.tabs.update(tabList[tab.id], { openerTabId: tabList[tab.openerTabId] ?? -1 }));

--- a/src/settings/defaultSettings.js
+++ b/src/settings/defaultSettings.js
@@ -49,7 +49,7 @@ export default [
             title: "tstDelayLabel",
             captions: ["tstDelayCaptionLabel"],
             type: "number",
-            min: 0,
+            min: -1,
             placeholder: 150,
             default: 150
           }


### PR DESCRIPTION
If it actually works properly, should fix #662 and resolve #274.

Manages to restore all tabs without any of them being out of place even with tree restoration delay disabled. Upon performance testing for ~2000 tabs, `restoreTabHierarchy()` adds ~900ms of latency on average on my system.

Delay can be bypassed by providing a value of `-1`. This makes the tab restoration substantially faster.
The option is kept there since it does freeze the browser UI until everything is open, which might not be desirable for everyone.

Minor problem: some tab managers like Sidebery may have to be toggled to reflect the corrected structure.

Might require additional testing from those interested to verify the reliability of this method