### PR TITLE
Update open.js to workaround Firefox window order bug

### DIFF
--- a/src/background/open.js
+++ b/src/background/open.js
@@ -91,7 +91,7 @@ export async function openSession(session, property = "openInNewWindow") {
           break;
       }
     } else {
-      openInNewWindow();
+      await openInNewWindow();
     }
   }
 }


### PR DESCRIPTION
Firefox window order bug:
https://bugzilla.mozilla.org/show_bug.cgi?id=1235231 
random order of bulk opening window request

When doing await per window opening is slower, but order seems preserved

Could fix issue:
https://github.com/sienori/Tab-Session-Manager/issues/1592
My feature request before I looked at the code:
https://github.com/sienori/Tab-Session-Manager/issues/1605
(My first GitHub pull-request is now a fact ; ))
