### PR TITLE
Fix Google Sign-In email cache issue on sign-out

### DIFF
--- a/src/background/cloudAuth.js
+++ b/src/background/cloudAuth.js
@@ -11,12 +11,14 @@ export const signInGoogle = async () => {
     const authCode = await getAuthCode();
     const { accessToken, expiresIn, refreshToken } = await getRefreshTokens(authCode);
     const email = await getEmail(accessToken);
-    setSettings("signedInEmail", email);
-    setSettings("accessToken", accessToken);
-    setSettings("refreshToken", refreshToken);
-    setTokenExpiration(expiresIn);
-    setSettings("lastSyncTime", 0);
-    setSettings("removedQueue", []);
+    await Promise.all([
+      setSettings("signedInEmail", email),
+      setSettings("accessToken", accessToken),
+      setSettings("refreshToken", refreshToken),
+      setTokenExpiration(expiresIn),
+      setSettings("lastSyncTime", 0),
+      setSettings("removedQueue", [])
+    ]);
     return true;
   } catch {
     return false;
@@ -30,11 +32,13 @@ export const signOutGoogle = async () => {
     const refreshToken = getSettings("refreshToken");
     revokeToken(accessToken);
     revokeToken(refreshToken);
-    setSettings("signedInEmail", "");
-    setSettings("accessToken", "");
-    setSettings("refreshToken", "");
-    setSettings("lastSyncTime", 0);
-    setSettings("removedQueue", []);
+    await Promise.all([
+      setSettings("signedInEmail", ""),
+      setSettings("accessToken", ""),
+      setSettings("refreshToken", ""),
+      setSettings("lastSyncTime", 0),
+      setSettings("removedQueue", [])
+    ]);
     return true;
   } catch {
     return false;
@@ -144,7 +148,7 @@ const getEmail = async accessToken => {
 
 const setTokenExpiration = async expirationSec => {
   const currentTimeMs = Date.now();
-  setSettings("tokenExpiration", currentTimeMs + expirationSec * 1000);
+  await setSettings("tokenExpiration", currentTimeMs + expirationSec * 1000);
 };
 
 export const refreshAccessToken = async (shouldShowLogin = true) => {
@@ -157,8 +161,10 @@ export const refreshAccessToken = async (shouldShowLogin = true) => {
 
   try {
     const { accessToken, expiresIn } = await getAccessToken(refreshToken);
-    setSettings("accessToken", accessToken);
-    setTokenExpiration(expiresIn);
+    await Promise.all([
+      setSettings("accessToken", accessToken),
+      setTokenExpiration(expiresIn)
+    ]);
     return accessToken;
   } catch (e) {
     const currentEmail = getSettings("signedInEmail");
@@ -167,10 +173,12 @@ export const refreshAccessToken = async (shouldShowLogin = true) => {
     });
     const { accessToken, expiresIn, refreshToken } = await getRefreshTokens(authCode);
     const email = await getEmail(accessToken);
-    setSettings("signedInEmail", email);
-    setSettings("accessToken", accessToken);
-    setSettings("refreshToken", refreshToken);
-    setTokenExpiration(expiresIn);
+    await Promise.all([
+      setSettings("signedInEmail", email),
+      setSettings("accessToken", accessToken),
+      setSettings("refreshToken", refreshToken),
+      setTokenExpiration(expiresIn)
+    ]);
     return accessToken;
   }
 };

--- a/src/options/components/SignInButton.js
+++ b/src/options/components/SignInButton.js
@@ -17,14 +17,18 @@ export default class SignInButton extends Component {
     const isSucceeded = await browser.runtime.sendMessage({
       message: "signInGoogle"
     });
-    if (isSucceeded) this.setState({ shouldSignIn: !this.state.shouldSignIn });
+    if (isSucceeded) {
+      const response = await browser.storage.local.get("Settings");
+      const signedInEmail = response.Settings?.signedInEmail || "";
+      this.setState({ shouldSignIn: false, signedInEmail });
+    }
   };
 
   handleSignOutClick = async () => {
     const isSucceeded = await browser.runtime.sendMessage({
       message: "signOutGoogle"
     });
-    if (isSucceeded) this.setState({ shouldSignIn: !this.state.shouldSignIn });
+    if (isSucceeded) this.setState({ shouldSignIn: true, signedInEmail: "" });
   };
 
   render() {


### PR DESCRIPTION
add awaits to setSettings calls in cloudAuth.js so that the methods only return once the settings are committed. in particular, this fixes a bug where the signed in email if you switch google accounts in the same session (sign out of an account, then sign back in with a different account) displays the wrong email