### PR TITLE
Optimize session lookup and migration efficiency

### DIFF
--- a/src/background/autoSave.js
+++ b/src/background/autoSave.js
@@ -2,7 +2,7 @@ import browser from "webextension-polyfill";
 import { v4 as uuidv4 } from "uuid";
 import log from "loglevel";
 import { openSession } from "./open.js";
-import { getSessionsByTag } from "./tag.js";
+import { getSessionsByTag, getLatestSessionByTag } from "./tag.js";
 import { loadCurrentSession, saveSession, removeSession } from "./save.js";
 import { getSettings } from "src/settings/settings";
 import { getTrackingInfo, updateTrackingSession } from "./track.js";
@@ -60,10 +60,10 @@ const updateTemp = async () => {
   try {
     const name = await getCurrentTabName();
     let session = await loadCurrentSession(name, ["temp"], "default");
-    const tempSessions = await getSessionsByTag("temp");
+    const tempSession = await getLatestSessionByTag("temp");
 
     //現在のセッションをtempとして保存
-    if (tempSessions[0]) session.id = tempSessions[0].id;
+    if (tempSession) session.id = tempSession.id;
     await saveSession(session, false);
 
     const { isTracking } = await getTrackingInfo();
@@ -112,10 +112,10 @@ export const autoSaveWhenWindowClose = async removedWindowId => {
   if (!getSettings("ifAutoSaveWhenClose")) return;
   log.info(logDir, "autoSaveWhenWindowClose()", removedWindowId);
 
-  const tempSessions = await getSessionsByTag("temp");
-  if (!tempSessions[0]) return;
+  const tempSession = await getLatestSessionByTag("temp");
+  if (!tempSession) return;
 
-  let session = tempSessions[0];
+  let session = tempSession;
   for (const windowId in session.windows) {
     if (windowId != removedWindowId) {
       delete session.windows[windowId];
@@ -148,11 +148,11 @@ export const autoSaveWhenWindowClose = async removedWindowId => {
 };
 
 export const autoSaveWhenExitBrowser = async () => {
-  const tempSessions = await getSessionsByTag("temp");
-  if (!tempSessions[0]) return;
+  const tempSession = await getLatestSessionByTag("temp");
+  if (!tempSession) return;
   log.info(logDir, "autoSaveWhenExitBrowser()");
 
-  let session = tempSessions[0];
+  let session = tempSession;
   if (!getSettings("useTabTitleforAutoSave"))
     session.name = browser.i18n.getMessage("browserExitSessionName");
   session.tag = ["browserExit"];
@@ -172,10 +172,10 @@ export const openLastSession = async () => {
   log.info(logDir, "openLastSession()");
 
   const currentWindows = await browser.windows.getAll();
-  const browserExitSessions = await getSessionsByTag("browserExit");
-  if (!browserExitSessions[0]) return;
+  const browserExitSession = await getLatestSessionByTag("browserExit");
+  if (!browserExitSession) return;
 
-  await openSession(browserExitSessions[0], "openInNewWindow");
+  await openSession(browserExitSession, "openInNewWindow");
 
   for (const window of currentWindows) {
     await browser.windows.remove(window.id);

--- a/src/background/tag.js
+++ b/src/background/tag.js
@@ -86,6 +86,31 @@ export async function getSessionsByTag(tag, needKeys = null) {
   return sessions;
 }
 
+export async function getLatestSessionByTag(tag) {
+  log.log(logDir, "getLatestSessionByTag()", tag);
+  const newestSort = (a, b) => {
+    return moment(b.date).unix() - moment(a.date).unix();
+  };
+  const isIncludesTag = (element, index, array) => {
+    return element.tag.includes(tag);
+  };
+
+  // Get all session keys with the necessary fields
+  const needKeys = ["id", "tag", "date"];
+  let sessionsKeyList = await Sessions.getAll(needKeys).catch(() => []);
+
+  sessionsKeyList = sessionsKeyList.filter(isIncludesTag);
+  sessionsKeyList.sort(newestSort);
+
+  if (sessionsKeyList.length === 0) return;
+  const latestSession = sessionsKeyList[0];
+
+  // Fetch the full session data for the latest session
+  let session = await Sessions.get(latestSession.id).catch(() => {});
+
+  return session;
+}
+
 export async function applyDeviceName() {
   const shouldSaveDeviceName = getSettings("shouldSaveDeviceName");
   const deviceName = getSettings("deviceName");

--- a/src/background/updateOldSessions.js
+++ b/src/background/updateOldSessions.js
@@ -20,22 +20,36 @@ export default async () => {
 
 const addNewValues = async () => {
   log.log(logDir, "addNewValues()");
-  const sessions = await Sessions.getAll().catch(() => {});
-  for (let session of sessions) {
+
+  // Get all session keys with the necessary fields
+  const needKeys = ["id", "date", "windowsNumber", "lastEditedTime"];
+  const sessionKeyList = await Sessions.getAll(needKeys).catch(() => []);
+
+  if (!sessionKeyList || sessionKeyList.length === 0) return;
+
+  for (const sessionKey of sessionKeyList) {
     let shouldUpdate = false;
+
+    if (sessionKey.windowsNumber === undefined) shouldUpdate = true;
+    if (typeof sessionKey.date !== "number") shouldUpdate = true;
+    if (!sessionKey.lastEditedTime) shouldUpdate = true;
+
+    if (!shouldUpdate) continue;
+
+    // Fetch the full session data only if an update is needed
+    let session = await Sessions.get(sessionKey.id).catch(() => {});
+    if (!session) continue;
+
     if (session.windowsNumber === undefined) {
       session.windowsNumber = Object.keys(session.windows).length;
-      shouldUpdate = true;
     }
     if (typeof session.date !== "number") {
       session.date = moment(session.date).valueOf();
-      shouldUpdate = true;
     }
     if (!session.lastEditedTime) {
       session.lastEditedTime = session.date;
-      shouldUpdate = true;
     }
-    if (shouldUpdate) await updateSession(session, true, false);
+    await updateSession(session, true, false);
   }
 };
 


### PR DESCRIPTION
This pull request improves session retrieval by introducing a `getLatestSessionByTag` function that fetches the latest session by tag, avoiding the need to load all saved sessions and reducing unnecessary data loading.

It mainly focuses on reducing memory spikes for power users with large session databases. In my testing using Firefox Profiler and capturing after the extension reload, the changes reduced memory usage from ~3.2 GB to ~250 MB.


Before:
<img width="1766" height="314" alt="before" src="https://github.com/user-attachments/assets/4637e0fb-1298-4f25-b0d4-12a544b23d6a" />

After:
<img width="1766" height="314" alt="after" src="https://github.com/user-attachments/assets/1cace4d5-af4b-441f-befd-3d949b275886" />

Related issue: #1566 