### PR TITLE
Virtualize rendering of session details list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "react-router": "^5.1.2",
         "react-router-dom": "^5.1.2",
         "react-transition-group": "^4.3.0",
+        "react-window": "^1.8.9",
         "url": "^0.11.0",
         "uuid": "^11.1.0",
         "webextension-polyfill": "^0.12.0"
@@ -7126,6 +7127,23 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/react-window": {
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.11.tgz",
+      "integrity": "sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
+      },
+      "engines": {
+        "node": ">8.0.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/readdirp": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react-highlight-words": "^0.16.0",
     "react-router": "^5.1.2",
     "react-router-dom": "^5.1.2",
+    "react-window": "^1.8.9",
     "react-transition-group": "^4.3.0",
     "url": "^0.11.0",
     "uuid": "^11.1.0",

--- a/src/popup/components/DetailsContainer.js
+++ b/src/popup/components/DetailsContainer.js
@@ -1,4 +1,5 @@
 import React, { Component } from "react";
+import { VariableSizeList } from "react-window";
 import browser from "webextension-polyfill";
 import browserInfo from "browser-info";
 import openUrl from "../actions/openUrl";
@@ -13,6 +14,10 @@ import WindowIncognitoFirefoxIcon from "../icons/window_incognito_firefox.svg";
 
 import "../styles/DetailsContainer.scss";
 import Highlighter from "react-highlight-words";
+
+const WINDOW_ROW_HEIGHT = 30;
+const TAB_ROW_HEIGHT = 30;
+const WINDOW_GAP_HEIGHT = 5;
 
 const FavIcon = props => (
   <img
@@ -75,61 +80,152 @@ const TabContainer = props => {
   );
 };
 
-class WindowContainer extends Component {
+export default class DetailsContainer extends Component {
   constructor(props) {
     super(props);
-    this.state = { isCollapsed: false };
+
+    this.state = {
+      collapsedSessionId: null,
+      collapsedWindowIds: {},
+      height: 0
+    };
   }
 
-  getTabsNumberText = () => {
-    const tabLabel = browser.i18n.getMessage("tabLabel");
-    const tabsLabel = browser.i18n.getMessage("tabsLabel");
-    const tabsNumber = Object.keys(this.props.tabs).length;
-    const tabsNumberText = `${tabsNumber} ${tabsNumber > 1 ? tabsLabel : tabLabel}`;
-    return tabsNumberText;
+  componentDidUpdate(prevProps, prevState) {
+    // Reset the scroll position and collapsed state when the session changes
+    if (prevProps.session.id !== this.props.session.id) {
+      this.list?.scrollTo(0);
+      this.setState({ collapsedSessionId: null, collapsedWindowIds: {} });
+    }
+
+    if (
+      prevProps.session !== this.props.session ||
+      prevProps.session.id !== this.props.session.id ||
+      prevState.collapsedWindowIds !== this.state.collapsedWindowIds
+    ) {
+      this.list?.resetAfterIndex(0);
+    }
+  }
+
+  componentWillUnmount() {
+    this.resizeObserver?.disconnect();
+  }
+
+  setContainerRef = container => {
+    if (this.container === container) return;
+
+    this.resizeObserver?.disconnect();
+    this.container = container;
+
+    if (!container) return;
+
+    // Calculate the height of the container and update the state when it changes
+    this.resizeObserver = new ResizeObserver(entries => {
+      const height = Math.floor(entries[0].contentRect.height);
+      if (height !== this.state.height) this.setState({ height });
+    });
+
+    this.resizeObserver.observe(container);
   };
 
-  handleRemoveClick = () => {
-    const { windowId, handleRemoveWindow } = this.props;
-    handleRemoveWindow(windowId);
+  getRows = () => {
+    // Generate a flat list of rows to render, including window rows and tab rows
+    const { session } = this.props;
+
+    const isCurrentSession = this.state.collapsedSessionId === session.id;
+
+    return Object.keys(session.windows).flatMap(windowId => {
+      const tabs = session.windows[windowId];
+      const isCollapsed = isCurrentSession && this.state.collapsedWindowIds[windowId];
+      const rows = [{ type: "window", windowId, tabs, isCollapsed }];
+
+      // Add sorted tab row to the list if the window is not collapsed
+      if (!isCollapsed) {
+        Object.values(tabs)
+          .sort((a, b) => a.index - b.index)
+          .forEach(tab => rows.push({ type: "tab", windowId, tab }));
+      }
+
+      rows.push({ type: "gap", windowId });
+      return rows;
+    });
   };
 
-  handleOpenClick = () => {
-    const { sessionId, windowId } = this.props;
-    sendOpenMessage(sessionId, "openInNewWindow", windowId);
+  getRowHeight = index => {
+    const row = this.rows[index];
+
+    switch (row.type) {
+      case "window":
+        return WINDOW_ROW_HEIGHT;
+      case "tab":
+        return TAB_ROW_HEIGHT;
+      default:
+        return WINDOW_GAP_HEIGHT;
+    }
   };
 
-  handleEditClick = e => {
-    const { sessionId, windowId } = this.props;
+  toggleCollapsed = windowId => {
+    const { session } = this.props;
+
+    this.setState(prevState => {
+      // Get current collapsed window IDs or reset if the session has changed
+      const collapsedWindowIds =
+        prevState.collapsedSessionId === session.id ? prevState.collapsedWindowIds : {};
+
+      // Add or remove the window ID from the collapsed window IDs based on its current state
+      return {
+        collapsedSessionId: session.id,
+        collapsedWindowIds: {
+          ...collapsedWindowIds,
+          [windowId]: !collapsedWindowIds[windowId]
+        }
+      };
+    });
+  };
+
+  handleRemoveTab = (windowId, tabId) => {
+    const { removeTab } = this.props;
+    removeTab(this.props.session, windowId, tabId);
+  };
+
+  handleRemoveWindowClick = windowId => {
+    const { removeWindow } = this.props;
+    removeWindow(this.props.session, windowId);
+  };
+
+  handleOpenWindowClick = windowId => {
+    const { session } = this.props;
+    sendOpenMessage(session.id, "openInNewWindow", windowId);
+  };
+
+  handleEditWindowClick = (e, windowId) => {
     const rect = e.target.getBoundingClientRect();
     const { x, y } = { x: e.pageX || rect.x, y: e.pageY || rect.y };
-    this.props.openMenu(x, y, <WindowMenuItems sessionId={sessionId} windowId={windowId} />);
+    this.props.openMenu(
+      x,
+      y,
+      <WindowMenuItems sessionId={this.props.session.id} windowId={windowId} />
+    );
     e.preventDefault();
   };
 
-  toggleCollapsed = () => {
-    const isCollapsed = !this.state.isCollapsed;
-    this.setState({ isCollapsed: isCollapsed });
-  };
-
-  render() {
-    const {
-      windowTitle,
-      windowId,
-      tabs,
-      windowsNumber,
-      allTabsNumber,
-      searchWords,
-      handleRemoveTab
-    } = this.props;
-    const sortedTabs = Object.values(tabs).sort((a, b) => a.index - b.index);
+  renderWindowRow = (row, style) => {
+    const { session } = this.props;
+    const { windowId, tabs, isCollapsed } = row;
+    const tabsNumber = Object.keys(tabs).length;
+    const tabLabel = browser.i18n.getMessage("tabLabel");
+    const tabsLabel = browser.i18n.getMessage("tabsLabel");
     const isIncognito = Object.values(tabs)[0].incognito;
+    const windowTitle = session?.windowsInfo?.[windowId]?.title;
 
     return (
-      <div className={`windowContainer ${this.state.isCollapsed ? "isCollapsed" : ""}`}>
-        <div className="windowInfo" onContextMenu={this.handleEditClick}>
+      <div
+        className={`windowContainer virtualRow ${isCollapsed ? "isCollapsed" : ""}`}
+        style={style}
+      >
+        <div className="windowInfo" onContextMenu={e => this.handleEditWindow(e, windowId)}>
           <div className="leftWrapper">
-            <button className="collapseButton" onClick={this.toggleCollapsed}>
+            <button className="collapseButton" onClick={() => this.toggleCollapsed(windowId)}>
               <CollapseIcon />
             </button>
             <div className="windowIcon">
@@ -145,67 +241,91 @@ class WindowContainer extends Component {
             </div>
             <button
               className="windowTitle"
-              onClick={this.handleOpenClick}
+              onClick={() => this.handleOpenWindow(windowId)}
               title={browser.i18n.getMessage("openInNewWindowLabel")}
             >
               {windowTitle ||
                 Object.values(tabs).find(tab => tab.active)?.title ||
                 browser.i18n.getMessage("windowLabel")}
             </button>
-            <span className="tabsNumber">{this.getTabsNumberText()}</span>
+            <span className="tabsNumber">
+              {tabsNumber} {tabsNumber > 1 ? tabsLabel : tabLabel}
+            </span>
           </div>
           <div className="buttonsContainer">
-            <EditButton handleClick={this.handleEditClick} />
-            {windowsNumber > 1 && <RemoveButton handleClick={this.handleRemoveClick} />}
+            <EditButton handleClick={e => this.handleEditWindow(e, windowId)} />
+            {session.windowsNumber > 1 && (
+              <RemoveButton handleClick={() => this.handleRemoveWindow(windowId)} />
+            )}
           </div>
         </div>
+      </div>
+    );
+  };
+
+  renderTabRow(row, style) {
+    const { session, searchWords } = this.props;
+
+    return (
+      <div className="windowContainer virtualRow" style={style}>
         <div className="tabs">
-          {Object.values(sortedTabs).map(tab => (
-            <TabContainer
-              tab={tab}
-              windowId={windowId}
-              allTabsNumber={allTabsNumber}
-              searchWords={searchWords}
-              handleRemoveTab={handleRemoveTab}
-              key={tab.id}
-            />
-          ))}
+          <TabContainer
+            tab={row.tab}
+            windowId={row.windowId}
+            allTabsNumber={session.tabsNumber}
+            searchWords={searchWords}
+            handleRemoveTab={this.handleRemoveTab}
+            key={`${session.id}-${row.windowId}-${row.tab.id}`}
+          />
         </div>
       </div>
     );
   }
+
+  renderRow = ({ index, style }) => {
+    const row = this.rows[index];
+
+    switch (row.type) {
+      case "window":
+        return this.renderWindowRow(row, style);
+      case "tab":
+        return this.renderTabRow(row, style);
+      default:
+        return <div style={style} />;
+    }
+  };
+
+  render() {
+    const { session } = this.props;
+
+    if (!session.windows) return null;
+
+    this.rows = this.getRows();
+
+    return (
+      <div className="detailsContainer" ref={this.setContainerRef}>
+        {this.state.height > 0 && (
+          <VariableSizeList
+            ref={list => (this.list = list)}
+            className="scrollbar"
+            height={this.state.height}
+            itemCount={this.rows.length}
+            itemKey={index => {
+              const row = this.rows[index];
+
+              if (row.type === "window") {
+                return `${session.id}-${row.type}-${row.windowId}`;
+              } else if (row.type === "tab") {
+                return `${session.id}-${row.type}-${row.windowId}-${row.tab.id}`;
+              }
+            }}
+            itemSize={this.getRowHeight}
+            width="100%"
+          >
+            {this.renderRow}
+          </VariableSizeList>
+        )}
+      </div>
+    );
+  }
 }
-
-export default props => {
-  const { session, searchWords, removeWindow, removeTab, openMenu } = props;
-
-  if (!session.windows) return null;
-
-  const handleRemoveWindow = windowId => {
-    removeWindow(session, windowId);
-  };
-
-  const handleRemoveTab = (windowId, tabId) => {
-    removeTab(session, windowId, tabId);
-  };
-
-  return (
-    <div className="detailsContainer scrollbar">
-      {Object.keys(session.windows).map(windowId => (
-        <WindowContainer
-          tabs={session.windows[windowId]}
-          windowTitle={session?.windowsInfo?.[windowId]?.title}
-          windowId={windowId}
-          sessionId={session.id}
-          windowsNumber={session.windowsNumber}
-          allTabsNumber={session.tabsNumber}
-          searchWords={searchWords}
-          handleRemoveWindow={handleRemoveWindow}
-          handleRemoveTab={handleRemoveTab}
-          openMenu={openMenu}
-          key={`${session.id}${windowId}`}
-        />
-      ))}
-    </div>
-  );
-};

--- a/src/popup/styles/DetailsContainer.scss
+++ b/src/popup/styles/DetailsContainer.scss
@@ -1,8 +1,13 @@
 .detailsContainer {
-  overflow-y: auto;
+  flex: 1;
+  min-height: 0;
   margin-top: 10px;
   .windowContainer {
     margin-bottom: 10px;
+
+    &.virtualRow {
+      margin-bottom: 0;
+    }
     .windowInfo,
     .tabs .tabContainer {
       display: flex;


### PR DESCRIPTION
This is one of two parts of an optimization aimed at improving popup‑opening speed. This part focuses on the frontend.

The new flow uses `react-window`, a React virtualization library. When a session contains a very large number of windows and tabs, the component renders only the items within the visible area, which increases rendering speed.

Please note that to make the virtualized list work without affecting the UI, the new flow changes `WindowContainer` from a root element to a row item element which is same level as `TabContainer`. Most of the changes you see involve flattening `WindowContainer` into a row item function similar to `TabContainer`.